### PR TITLE
Use yaml outputter instead of json outputter

### DIFF
--- a/ContentScripts/SystemPrep-LinuxSaltInstall.py
+++ b/ContentScripts/SystemPrep-LinuxSaltInstall.py
@@ -264,7 +264,7 @@ def main(saltinstallmethod='git',
                                 'saltcall.results.log'))
     salt_debug_logfile = salt_debug_log or os.sep.join((workingdir,
                                 'saltcall.debug.log'))
-    saltcall_arguments = '--out json --out-file {0} --return local --log-file ' \
+    saltcall_arguments = '--out yaml --out-file {0} --return local --log-file ' \
                          '{1} --log-file-level debug' \
                          .format(salt_results_logfile, salt_debug_logfile)
 
@@ -455,8 +455,8 @@ def main(saltinstallmethod='git',
                             'Exception: {1}' \
                             .format(salt_results_logfile, exc)
             raise SystemError(error_message)
-        if (not re.search('"result": false', salt_results)) and \
-           (re.search('"result": true', salt_results)):
+        if (not re.search('result: false', salt_results)) and \
+           (re.search('result: true', salt_results)):
             #At least one state succeeded, and no states failed, so log success
             print('Salt states applied successfully! Details are in the log, '
                   '{0}'.format(salt_results_logfile))

--- a/ContentScripts/SystemPrep-WindowsSaltInstall.ps1
+++ b/ContentScripts/SystemPrep-WindowsSaltInstall.ps1
@@ -245,7 +245,7 @@ if (-not $SaltResultsLog) {
 else {
     $SaltResultsLogFile = $SaltResultsLog
 }
-$SaltStateArguments = "--out json --out-file ${SaltResultsLogFile} --return local --log-file ${SaltDebugLogFile} --log-file-level debug"
+$SaltStateArguments = "--out yaml --out-file ${SaltResultsLogFile} --return local --log-file ${SaltDebugLogFile} --log-file-level debug"
 
 log -LogTag ${ScriptName} "Installing salt -- ${SaltInstaller}"
 $SaltInstallResult = Start-Process -FilePath $SaltInstaller.FullName -ArgumentList "/S" -NoNewWindow -PassThru -Wait
@@ -398,8 +398,8 @@ else {
         log -LogTag ${ScriptName} "Return code of salt-call: $(${ApplyStatesResult}.ExitCode)"
     }
     # Check for errors in the results file
-    if ((-not (Select-String -Path ${SaltResultsLogFile} -Pattern '"result": false')) -and
-        (Select-String -Path ${SaltResultsLogFile} -Pattern '"result": true')) {
+    if ((-not (Select-String -Path ${SaltResultsLogFile} -Pattern 'result: false')) -and
+        (Select-String -Path ${SaltResultsLogFile} -Pattern 'result: true')) {
         # At least one state succeeded, and no states failed, so log success
         log -LogTag ${ScriptName} "Salt states applied successfully! Details are in the log, ${SaltResultsLogFile}"
     }


### PR DESCRIPTION
This is a workaround for where the json outputter generates a
traceback when the results output contains byte string with
binary data.