### PR TITLE
Set grain `join-domain:oupath`

### DIFF
--- a/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1
+++ b/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1
@@ -13,6 +13,8 @@ Param(
     ,
     $EntEnv = $false
     ,
+    $OuPath = $false
+    ,
     [Bool]$SourceIsS3Bucket = $false
     ,
     [String]$AwsRegion = 'us-east-1'
@@ -34,6 +36,7 @@ $ErrorActionPreference = "Stop"
 $SystemPrepParams = @{
     AshRole = "${AshRole}"
     EntEnv = ${EntEnv}
+    OuPath = ${OuPath}
     SaltStates = "${SaltStates}"
     SaltContentUrl = "${SaltContentUrl}"
     NoReboot = ${NoReboot}

--- a/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-DomainController.txt
+++ b/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-DomainController.txt
@@ -1,10 +1,12 @@
 <powershell>
 # Define User variables
 $EntEnv = $false
+$OuPath = $false
 $SystemPrepMasterScriptUrl = 'https://s3.amazonaws.com/systemprep/MasterScripts/SystemPrep-WindowsMaster.ps1'
 $SystemPrepParams = @{
     AshRole = "DomainController"
     EntEnv = $EntEnv
+    OuPath = $OuPath
     SaltStates = "Highstate"
     SaltContentUrl = "https://s3.amazonaws.com/systemprep-content/windows/salt/salt-content.zip"
     NoReboot = $false

--- a/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-MemberServer.txt
+++ b/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-MemberServer.txt
@@ -1,10 +1,12 @@
 <powershell>
 # Define User variables
 $EntEnv = $false
+$OuPath = $false
 $SystemPrepMasterScriptUrl = 'https://s3.amazonaws.com/systemprep/MasterScripts/SystemPrep-WindowsMaster.ps1'
 $SystemPrepParams = @{
     AshRole = "MemberServer"
     EntEnv = $EntEnv
+    OuPath = $OuPath
     SaltStates = "Highstate"
     SaltContentUrl = "https://s3.amazonaws.com/systemprep-content/windows/salt/salt-content.zip"
     NoReboot = $false

--- a/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows.txt
+++ b/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows.txt
@@ -1,10 +1,12 @@
 <powershell>
 # Define User variables
 $EntEnv = $false
+$OuPath = $false
 $SystemPrepMasterScriptUrl = 'https://s3.amazonaws.com/systemprep/MasterScripts/SystemPrep-WindowsMaster.ps1'
 $SystemPrepParams = @{
     AshRole = "MemberServer"
     EntEnv = $EntEnv
+    OuPath = $OuPath
     SaltStates = "Highstate"
     SaltContentUrl = "https://s3.amazonaws.com/systemprep-content/windows/salt/salt-content.zip"
     NoReboot = $false

--- a/ContentScripts/SystemPrep-LinuxSaltInstall.py
+++ b/ContentScripts/SystemPrep-LinuxSaltInstall.py
@@ -176,6 +176,7 @@ def main(saltinstallmethod='git',
          salt_results_log=None,
          salt_debug_log=None,
          entenv='false',
+         oupath=None,
          sourceiss3bucket='false',
          **kwargs):
     """
@@ -217,6 +218,11 @@ def main(saltinstallmethod='git',
                    'false' does not set the custom grain
                    'true' TODO: detect the environment from EC2 metadata / tags
                    '*' set the custom grain to the `entenv` parameter value
+    :param oupath: str, controls whether to write a salt custom grain,
+                   join-domain:oupath. If set, and the salt-content.zip
+                   archive contains directives to join the domain, the
+                   join-domain formula will place the computer object in the
+                   OU specified by this grain.
     :param kwargs: dict, catch-all for other params that do not apply to this
                    content script
     :raise SystemError: error raised whenever an issue is encountered
@@ -244,6 +250,11 @@ def main(saltinstallmethod='git',
     print('    formulastoinclude = {0}'.format(formulastoinclude))
     print('    formulaterminationstrings = {0}'.format(formulaterminationstrings))
     print('    saltstates = {0}'.format(saltstates))
+    print('    salt_results_log = {0}'.format(salt_results_log))
+    print('    salt_debug_log = {0}'.format(salt_debug_log))
+    print('    sourceiss3bucket = {0}'.format(sourceiss3bucket))
+    print('    entenv = {0}'.format(entenv))
+    print('    oupath = {0}'.format(oupath))
     for key, value in kwargs.items():
         print('    {0} = {1}'.format(key, value))
 
@@ -403,10 +414,15 @@ def main(saltinstallmethod='git',
     if entenv == True:
         # TODO: Get environment from EC2 metadata or tags
         entenv = entenv
-    print('Setting systemprep grain...')
+    print('Setting grain `systemprep`...')
     systemprepgrainresult = os.system(
         '{0} --local grains.setval systemprep \'{{"enterprise_environment":'
         '"{1}"}}\''.format(saltcall, entenv))
+    if oupath:
+        print('Setting grain `join-domain`...')
+        joindomaingrainresult = os.system(
+            '{0} --local grains.setval "join-domain" \'{{"oupath":'
+            '"{1}"}}\''.format(saltcall, oupath))
 
     # Sync custom modules
     print('Syncing custom salt modules...')

--- a/Utils/systemprep-updatecontent.ps1
+++ b/Utils/systemprep-updatecontent.ps1
@@ -7,6 +7,9 @@ Param(
     [ValidateSet('None','Workstation','MemberServer','DomainController')]
     [String] $SystemRole
     ,
+    [Parameter(Mandatory=$false, Position=2, ValueFromPipeline=$false)]
+    $OuPath = $false
+    ,
     [Parameter(Mandatory=$false, ValueFromPipeline=$false)]
     [String] $BootstrapUrl = 'https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1'
 )
@@ -81,7 +84,8 @@ END
     # Create hash table of parameters to pass to the bootstrapper
     $BootstrapParams = @{
         AshRole = "${SystemRole}"
-        EntEnv = "${Environment}"
+        EntEnv = ${Environment}
+        OuPath = ${OuPath}
         SaltStates = "None"
         NoReboot = $true
     }


### PR DESCRIPTION
This allows a user to specify the param `oupath` in the bootstrapper. The value of this param will be written as a grain, `join-domain:oupath`. If this grain is set when the join-domain formula joins an instance to a domain, it will use the value of this grain to specify in which OU the instance should be placed.