### PR TITLE
cfn: incorporate application script into example templates

### DIFF
--- a/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1
+++ b/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1
@@ -104,7 +104,7 @@ function Set-OutputBuffer($Width=10000) {
            "hkcu:\console\%SystemRoot%_SysWOW64_WindowsPowerShell_v1.0_powershell.exe")
     # other titles are ignored
     foreach ($key in $keys) {
-        if (!(test-path $key)) {md $key -verbose}
+        md $key -verbose -force
         Set-RegistryValue $key FontSize 0x00050000
         Set-RegistryValue $key ScreenBufferSize 0x02000200
         Set-RegistryValue $key WindowSize 0x00200200

--- a/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-DomainController.txt
+++ b/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-DomainController.txt
@@ -87,7 +87,7 @@ function Set-OutputBuffer($Width=10000) {
            "hkcu:\console\%SystemRoot%_SysWOW64_WindowsPowerShell_v1.0_powershell.exe")
     # other titles are ignored
     foreach ($key in $keys) {
-        if (!(test-path $key)) {md $key -verbose}
+        md $key -verbose -force
         Set-RegistryValue $key FontSize 0x00050000
         Set-RegistryValue $key ScreenBufferSize 0x02000200
         Set-RegistryValue $key WindowSize 0x00200200

--- a/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-MemberServer.txt
+++ b/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-MemberServer.txt
@@ -87,7 +87,7 @@ function Set-OutputBuffer($Width=10000) {
            "hkcu:\console\%SystemRoot%_SysWOW64_WindowsPowerShell_v1.0_powershell.exe")
     # other titles are ignored
     foreach ($key in $keys) {
-        if (!(test-path $key)) {md $key -verbose}
+        md $key -verbose -force
         Set-RegistryValue $key FontSize 0x00050000
         Set-RegistryValue $key ScreenBufferSize 0x02000200
         Set-RegistryValue $key WindowSize 0x00200200

--- a/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows.txt
+++ b/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows.txt
@@ -87,7 +87,7 @@ function Set-OutputBuffer($Width=10000) {
            "hkcu:\console\%SystemRoot%_SysWOW64_WindowsPowerShell_v1.0_powershell.exe")
     # other titles are ignored
     foreach ($key in $keys) {
-        if (!(test-path $key)) {md $key -verbose}
+        md $key -verbose -force
         Set-RegistryValue $key FontSize 0x00050000
         Set-RegistryValue $key ScreenBufferSize 0x02000200
         Set-RegistryValue $key WindowSize 0x00200200

--- a/Utils/cfn/systemprep-lx-autoscale.template
+++ b/Utils/cfn/systemprep-lx-autoscale.template
@@ -1,8 +1,24 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description" : "This templates creates an Autoscaling Group and Launch Configuration that deploy RHEL6 instances with the SystemPrep bootstrapper, which applies the DISA STIG.",
+    "Description" : "This templates creates an Autoscaling Group and Launch Configuration that deploy Linux instances with the SystemPrep bootstrapper, which applies the DISA STIG.",
     "Parameters" :
     {
+        "AmiId" :
+        {
+            "Description" : "ID of the AMI to launch",
+            "Type" : "String"
+        },
+        "AmiDistro" :
+        {
+            "Description" : "Linux distro of the AMI",
+            "Type" : "String",
+            "AllowedValues" :
+            [
+                "AmazonLinux",
+                "RedHat",
+                "CentOS"
+            ]
+        },
         "BootstrapURL" :
         {
             "Description" : "URL to the SystemPrep Bootstrapper",
@@ -61,27 +77,11 @@
     },
     "Mappings" :
     {
-        "AWSInstanceType2Arch" :
+        "Distro2RootDevice" :
         {
-            "t2.micro" : { "Arch" : "64" },
-            "t2.small" : { "Arch" : "64" },
-            "t2.medium" : { "Arch" : "64" },
-            "c4.large" : { "Arch" : "64" },
-            "c4.xlarge" : { "Arch" : "64" },
-            "m4.large" : { "Arch" : "64" },
-            "m4.xlarge" : { "Arch" : "64" }
-        },
-        "AWSRegionArch2AMI" :
-        {
-            "us-east-1" : { "64" : "ami-0d28fe66" },
-            "us-west-2" : { "64" : "ami-75f3f145" },
-            "us-west-1" : { "64" : "ami-5b8a781f" },
-            "eu-west-1" : { "64" : "ami-78d29c0f" },
-            "eu-central-1" : { "64" : "ami-8e96ac93" },
-            "ap-southeast-1" : { "64" : "ami-faedeea8" },
-            "ap-northeast-1" : { "64" : "ami-78379d78" },
-            "ap-southeast-2" : { "64" : "ami-7f0d4b45" },
-            "sa-east-1" : { "64" : "ami-d1d35ccc" }
+            "AmazonLinux" : { "DeviceName" : "xvda" },
+            "RedHat" : { "DeviceName" : "sda1" },
+            "CentOS" : { "DeviceName" : "sda1" }
         }
     },
     "Resources" :
@@ -123,35 +123,23 @@
             "Type" : "AWS::AutoScaling::LaunchConfiguration",
             "Properties" :
             {
-                "ImageId" :
-                {
-                    "Fn::FindInMap" :
-                    [
-                        "AWSRegionArch2AMI",
-                        {
-                            "Ref" : "AWS::Region"
-                        },
-                        {
-                            "Fn::FindInMap" :
-                            [
-                                "AWSInstanceType2Arch",
-                                {
-                                    "Ref" : "InstanceType"
-                                },
-                                "Arch"
-                            ]
-                        }
-                    ]
-                },
-                "InstanceType" :
-                {
-                    "Ref" : "InstanceType"
-                },
+                "ImageId" : { "Ref" : "AmiId" },
+                "InstanceType" : { "Ref" : "InstanceType" },
                 "AssociatePublicIpAddress" : "true",
                 "BlockDeviceMappings" :
                 [
                     {
-                        "DeviceName" : "/dev/sda1",
+                        "DeviceName" :
+                        { "Fn::Join" : [ "", [
+                            "/dev/",
+                            { "Fn::FindInMap" :
+                                [
+                                    "Distro2RootDevice",
+                                    { "Ref" : "AmiDistro" },
+                                    "DeviceName"
+                                ]
+                            }
+                        ]]},
                         "Ebs" :
                         {
                             "VolumeType" : "gp2",

--- a/Utils/cfn/systemprep-lx-autoscale.template
+++ b/Utils/cfn/systemprep-lx-autoscale.template
@@ -173,27 +173,56 @@
                     { "Fn::Join" : [ "", [
                         "#!/bin/bash -x\n",
 
+                        "# Get pip\n",
                         "curl --silent --show-error --retry 5 -L ",
                         "https://bootstrap.pypa.io/get-pip.py",
                         " | python", "\n",
 
+                        "# Add pip to path\n",
                         "hash pip 2> /dev/null || ",
                         "PATH=\"${PATH}:/usr/local/bin\"", "\n",
 
-                        "pip install ",
-                        "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
-                        "\n",
+                        "# Upgrade setuptools\n",
+                        "pip install --upgrade setuptools\n",
 
+                        "# Fix python urllib3 warnings\n",
+                        "yum -y install gcc python-devel libffi-devel openssl-devel\n",
+                        "pip install pyopenssl ndg-httpsclient pyasn1\n",
+
+                        "# Get cfn utils\n",
+                        "pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n",
+
+                        "# Remove gcc now that it is no longer needed\n",
+                        "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
+
+                        "# Fixup cfn utils\n",
+                        "INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat ",
+                        "2> /dev/null || echo /usr/init/redhat)\n",
+                        "chmod 775 ${INITDIR}/cfn-hup\n",
+                        "ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
+                        "chkconfig --add cfn-hup\n",
+                        "chkconfig cfn-hup on\n",
+                        "mkdir -p /opt/aws/bin\n",
+                        "BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin ",
+                        "2> /dev/null || echo /usr/bin)\n",
+                        "for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup ",
+                        "cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
+                        "do\n",
+                        "    ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
+                        "    echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
+                        "done\n",
+
+                        "# Add cfn-signal to path\n",
                         "hash cfn-signal 2> /dev/null || ",
                         "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
                         "\n",
 
+                        "# Execute SystemPrep Bootstrapper\n",
                         "curl --silent --show-error --retry 5 -L ",
                         {
                             "Ref" : "BootstrapURL"
                         },
                         " | bash", "\n",
-
                         "result=$?", "\n",
 
                         "cfn-signal -e $result ",

--- a/Utils/cfn/systemprep-lx-autoscale.template
+++ b/Utils/cfn/systemprep-lx-autoscale.template
@@ -1,12 +1,13 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description" : "This templates creates an Autoscaling Group and Launch Configuration that deploy Linux instances with the SystemPrep bootstrapper, which applies the DISA STIG.",
+    "Description" : "This template creates an Autoscaling Group and Launch Configuration that deploy Linux instances with the SystemPrep bootstrapper, which applies the DISA STIG.",
     "Parameters" :
     {
         "AmiId" :
         {
             "Description" : "ID of the AMI to launch",
-            "Type" : "String"
+            "Type" : "String",
+            "AllowedPattern" : "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$"
         },
         "AmiDistro" :
         {
@@ -15,15 +16,32 @@
             "AllowedValues" :
             [
                 "AmazonLinux",
-                "RedHat",
-                "CentOS"
+                "CentOS",
+                "RedHat"
             ]
         },
-        "BootstrapURL" :
+        "AppScriptParams" :
         {
-            "Description" : "URL to the SystemPrep Bootstrapper",
+            "Description" : "Parameter string to pass to the application script. This parameter is ignored unless \"AppScriptUrl\" is provided",
+            "Type" : "String"
+        },
+        "AppScriptShell" :
+        {
+            "Description" : "Shell with which to execute the application script. This parameter is ignored unless \"AppScriptUrl\" is provided",
             "Type" : "String",
-            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Linux.sh"
+            "Default" : "bash",
+            "AllowedValues" :
+            [
+                "bash",
+                "python"
+            ]
+        },
+        "AppScriptUrl" :
+        {
+            "Description" : "URL to the application script. Leave blank to launch without an application script",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^http://.*$|^https://.*$"
         },
         "KeyPairName" :
         {
@@ -40,6 +58,7 @@
                 "t2.micro",
                 "t2.small",
                 "t2.medium",
+                "t2.large",
                 "c4.large",
                 "c4.xlarge",
                 "m4.large",
@@ -56,7 +75,7 @@
         {
             "Description" : "Maximum number of instances in the Autoscaling Group",
             "Type" : "Number",
-            "Default" : "1"
+            "Default" : "2"
         },
         "DesiredCapacity" :
         {
@@ -64,15 +83,120 @@
             "Type" : "Number",
             "Default" : "1"
         },
+        "NoPublicIp" :
+        {
+            "Description" : "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
+            "Type" : "String",
+            "Default" : "true",
+            "AllowedValues" :
+            [
+                "false",
+                "true"
+            ]
+        },
+        "NoReboot" :
+        {
+            "Description" : "Controls whether to reboot the instance as the last step of cfn-init execution",
+            "Type" : "String",
+            "Default" : "false",
+            "AllowedValues" :
+            [
+                "false",
+                "true"
+            ]
+        },
+        "NoUpdates" :
+        {
+            "Description" : "Controls whether to run yum update during a stack update (on the initial instance launch, SystemPrep _always_ installs updates)",
+            "Type" : "String",
+            "Default" : "false",
+            "AllowedValues" :
+            [
+                "false",
+                "true"
+            ]
+        },
         "SecurityGroupIds" :
         {
-            "Description" : "List of security groups to apply to the instance",
+            "Description" : "List of security groups to apply to the instance(s)",
             "Type" : "List<AWS::EC2::SecurityGroup::Id>"
         },
         "SubnetIds" :
         {
             "Type" : "List<AWS::EC2::Subnet::Id>",
             "Description" : "List of subnets to associate to the Autoscaling Group"
+        },
+        "SystemPrepBootstrapUrl" :
+        {
+            "Description" : "URL to the SystemPrep Bootstrapper",
+            "Type" : "String",
+            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Linux.sh",
+            "AllowedPattern" : "^http://.*\\.sh$|^https://.*\\.sh$"
+        },
+        "SystemPrepEnvironment" :
+        {
+            "Description" : "Environment in which the instance is being deployed",
+            "Type" : "String",
+            "Default" : "false",
+            "AllowedValues" :
+            [
+                "false",
+                "dev",
+                "test",
+                "prod"
+            ]
+        },
+        "SystemPrepOuPath" :
+        {
+            "Description" : "DN of the OU to place the instance when joining a domain. If blank and \"SystemPrepEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"SystemPrepEnvironment\" is \"false\"",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^(OU=.+,)+(DC=.+)+$"
+        },
+        "ToggleCfnInitUpdate" :
+        {
+            "Description" : "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
+            "Type" : "String",
+            "Default" : "A",
+            "AllowedValues" :
+            [
+                "A",
+                "B"
+            ]
+        },
+        "ToggleNewInstances" :
+        {
+            "Description" : "A/B toggle that forces a change to instance userdata, triggering new instances via the Autoscale update policy",
+            "Type" : "String",
+            "Default" : "A",
+            "AllowedValues" :
+            [
+                "A",
+                "B"
+            ]
+        }
+    },
+    "Conditions" :
+    {
+        "ExecuteAppScript" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AppScriptUrl" }, "" ] } ]
+        },
+        "UseOuPath" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "SystemPrepOuPath" }, "" ] } ]
+        },
+        "InstallUpdates" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoUpdates" }, "true" ] } ]
+        },
+        "Reboot" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoReboot" }, "true" ] } ]
+        },
+        "AssignPublicIp" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoPublicIp" }, "true" ] } ]
         }
     },
     "Mappings" :
@@ -89,12 +213,20 @@
         "SystemPrepAutoScalingGroup" :
         {
             "Type" : "AWS::AutoScaling::AutoScalingGroup",
+            "UpdatePolicy" : {
+                "AutoScalingRollingUpdate" : {
+                    "MinInstancesInService" : "1",
+                    "MaxBatchSize" : "2",
+                    "WaitOnResourceSignals" : "true",
+                    "PauseTime" : "PT30M"
+                }
+            },
             "CreationPolicy" :
             {
                 "ResourceSignal" :
                 {
-                    "Count" : "1",
-                    "Timeout" : "PT20M"
+                    "Count" : { "Ref" : "DesiredCapacity" },
+                    "Timeout" : "PT30M"
                 }
             },
             "Properties" :
@@ -110,7 +242,6 @@
                         "Key" : "Name",
                         "Value" :
                         { "Fn::Join" : [ "", [
-                            "SystemPrep-Linux-",
                             { "Ref" : "AWS::StackName" }
                         ] ] },
                         "PropagateAtLaunch" : "true"
@@ -121,11 +252,259 @@
         "SystemPrepLaunchConfig" :
         {
             "Type" : "AWS::AutoScaling::LaunchConfiguration",
+            "Metadata" : {
+                "ToggleCfnInitUpdate" : { "Ref" : "ToggleCfnInitUpdate" },
+                "AWS::CloudFormation::Init" :
+                {
+                    "configSets" :
+                    {
+                        "launch" :
+                        [
+                            "setup",
+                            "systemprep-launch",
+                            {
+                                "Fn::If" :
+                                [
+                                    "ExecuteAppScript",
+                                    "make-app",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            "finalize",
+                            {
+                                "Fn::If" :
+                                [
+                                    "Reboot",
+                                    "reboot",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            }
+                        ],
+                        "update" :
+                        [
+                            "setup",
+                            {
+                                "Fn::If" :
+                                [
+                                    "InstallUpdates",
+                                    "install-updates",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            "systemprep-update",
+                            {
+                                "Fn::If" :
+                                [
+                                    "ExecuteAppScript",
+                                    "make-app",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            "finalize",
+                            {
+                                "Fn::If" :
+                                [
+                                    "Reboot",
+                                    "reboot",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            }
+                        ]
+                    },
+                    "setup" :
+                    {
+                        "files" :
+                        {
+                            "/etc/cfn/cfn-hup.conf" :
+                            {
+                                "content" :
+                                { "Fn::Join" : ["", [
+                                    "[main]\n",
+                                    "stack=", { "Ref" : "AWS::StackId" }, "\n",
+                                    "region=", { "Ref" : "AWS::Region" }, "\n",
+                                    "interval=1", "\n",
+                                    "verbose=true", "\n"
+                                ]]},
+                                "mode"    : "000400",
+                                "owner"   : "root",
+                                "group"   : "root"
+                            },
+                            "/etc/cfn/hooks.d/cfn-auto-reloader.conf" :
+                            {
+                                "content" :
+                                { "Fn::Join" : ["", [
+                                    "[cfn-auto-reloader-hook]\n",
+                                    "triggers=post.update\n",
+                                    "path=Resources.SystemPrepLaunchConfig.Metadata\n",
+                                    "action=/opt/aws/bin/cfn-init -v -c update",
+                                    " --stack ", { "Ref" : "AWS::StackName" },
+                                    " --resource SystemPrepLaunchConfig",
+                                    " --region ", { "Ref" : "AWS::Region" }, "\n",
+                                    "runas=root\n"
+                                ]]},
+                                "mode" : "000400",
+                                "owner" : "root",
+                                "group" : "root"
+                            },
+                            "/etc/cfn/scripts/systemprep-bootstrapper.sh" :
+                            {
+                                "source" : { "Ref" : "SystemPrepBootstrapUrl" },
+                                "mode" : "000700",
+                                "owner" : "root",
+                                "group" : "root"
+                            }
+                        },
+                        "services" :
+                        {
+                            "sysvinit" :
+                            {
+                                "cfn-hup" :
+                                {
+                                    "enabled" : "true",
+                                    "ensureRunning" : "true",
+                                    "files" :
+                                    [
+                                        "/etc/cfn/cfn-hup.conf",
+                                        "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "install-updates" :
+                    {
+                        "commands" :
+                        {
+                            "10-install-updates" :
+                            {
+                                "command" : "yum -y update"
+                            }
+                        }
+                    },
+                    "systemprep-launch" :
+                    {
+                        "commands" :
+                        {
+                            "10-systemprep-launch" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    "bash /etc/cfn/scripts/systemprep-bootstrapper.sh",
+                                    " --noreboot",
+                                    " --environment ",
+                                    { "Ref" : "SystemPrepEnvironment" },
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseOuPath",
+                                            { "Fn::Join" : [ "", [
+                                                " --oupath \"",
+                                                { "Ref" : "SystemPrepOuPath" },
+                                                "\""
+                                            ]]},
+                                            ""
+                                        ]
+                                    }
+                                ]]}
+                            }
+                        }
+                    },
+                    "systemprep-update" :
+                    {
+                        "commands" :
+                        {
+                            "10-systemprep-update" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    "bash /etc/cfn/scripts/systemprep-bootstrapper.sh",
+                                    " --saltstates None",
+                                    " --noreboot",
+                                    " --environment ",
+                                    { "Ref" : "SystemPrepEnvironment" },
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseOuPath",
+                                            { "Fn::Join" : [ "", [
+                                                " --oupath \"",
+                                                { "Ref" : "SystemPrepOuPath" },
+                                                "\""
+                                            ]]},
+                                            ""
+                                        ]
+                                    }
+                                ]]}
+                            }
+                        }
+                    },
+                    "make-app" :
+                    {
+                        "files" :
+                        {
+                            "/etc/cfn/scripts/make-app" :
+                            {
+                                "source" : { "Ref" : "AppScriptUrl" },
+                                "mode" : "000700",
+                                "owner" : "root",
+                                "group" : "root"
+                            }
+                        },
+                        "commands" :
+                        {
+                            "10-make-app" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    { "Ref" : "AppScriptShell" },
+                                    " /etc/cfn/scripts/make-app ",
+                                    { "Ref" : "AppScriptParams" }
+                                ]]}
+                            }
+                        }
+                    },
+                    "finalize" :
+                    {
+                        "commands" :
+                        {
+                            "10-signal-success" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    "/opt/aws/bin/cfn-signal -e 0",
+                                    " --stack ", { "Ref" : "AWS::StackName" },
+                                    " --resource SystemPrepAutoScalingGroup",
+                                    " --region ", { "Ref" : "AWS::Region"}, "\n"
+                                ]]},
+                                "ignoreErrors" : "true"
+                            }
+                        }
+                    },
+                    "reboot" :
+                    {
+                        "commands" :
+                        {
+                            "10-reboot" :
+                            {
+                                "command" : "shutdown -r +1 &"
+                            }
+                        }
+                    }
+                }
+            },
             "Properties" :
             {
                 "ImageId" : { "Ref" : "AmiId" },
                 "InstanceType" : { "Ref" : "InstanceType" },
-                "AssociatePublicIpAddress" : "true",
+                "AssociatePublicIpAddress" :
+                {
+                    "Fn::If" :
+                    [
+                        "AssignPublicIp",
+                        "true",
+                        "false"
+                    ]
+                },
                 "BlockDeviceMappings" :
                 [
                     {
@@ -159,26 +538,30 @@
                 {
                     "Fn::Base64" :
                     { "Fn::Join" : [ "", [
-                        "#!/bin/bash -x\n",
+                        "#!/bin/bash -xe\n\n",
+
+                        "# CFN LaunchConfig Update Toggle: ",
+                        { "Ref" : "ToggleNewInstances" },
+                        "\n\n",
 
                         "# Get pip\n",
                         "curl --silent --show-error --retry 5 -L ",
                         "https://bootstrap.pypa.io/get-pip.py",
-                        " | python", "\n",
+                        " | python", "\n\n",
 
                         "# Add pip to path\n",
                         "hash pip 2> /dev/null || ",
-                        "PATH=\"${PATH}:/usr/local/bin\"", "\n",
+                        "PATH=\"${PATH}:/usr/local/bin\"", "\n\n",
 
                         "# Upgrade setuptools\n",
-                        "pip install --upgrade setuptools\n",
+                        "pip install --upgrade setuptools\n\n",
 
                         "# Fix python urllib3 warnings\n",
                         "yum -y install gcc python-devel libffi-devel openssl-devel\n",
-                        "pip install pyopenssl ndg-httpsclient pyasn1\n",
+                        "pip install pyopenssl ndg-httpsclient pyasn1\n\n",
 
                         "# Get cfn utils\n",
-                        "pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n",
+                        "pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n\n",
 
                         "# Remove gcc now that it is no longer needed\n",
                         "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
@@ -198,25 +581,25 @@
                         "do\n",
                         "    ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
                         "    echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
-                        "done\n",
+                        "done\n\n",
 
                         "# Add cfn-signal to path\n",
                         "hash cfn-signal 2> /dev/null || ",
                         "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
-                        "\n",
+                        "\n\n",
 
-                        "# Execute SystemPrep Bootstrapper\n",
-                        "curl --silent --show-error --retry 5 -L ",
-                        {
-                            "Ref" : "BootstrapURL"
-                        },
-                        " | bash", "\n",
-                        "result=$?", "\n",
-
-                        "cfn-signal -e $result ",
+                        "# Execute cfn-init\n",
+                        "/opt/aws/bin/cfn-init -v -c launch",
                         " --stack ", { "Ref" : "AWS::StackName" },
-                        " --resource SystemPrepAutoScalingGroup ",
-                        " --region ", { "Ref" : "AWS::Region"}, "\n"
+                        " --resource SystemPrepLaunchConfig",
+                        " --region ", { "Ref" : "AWS::Region" }, " ||",
+                        " ( echo 'ERROR: cfn-init failed! Aborting!';",
+                        " /opt/aws/bin/cfn-signal -e 1",
+                        "  --stack ", { "Ref" : "AWS::StackName" },
+                        "  --resource SystemPrepAutoScalingGroup",
+                        "  --region ", { "Ref" : "AWS::Region"}, ";",
+                        " exit 1",
+                        " )\n\n"
                     ] ] }
                 }
             }

--- a/Utils/cfn/systemprep-lx-autoscale.template
+++ b/Utils/cfn/systemprep-lx-autoscale.template
@@ -1,21 +1,26 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description"              : "This templates creates an Autoscaling Group and Launch Configuration that deploy RHEL6 instances with the SystemPrep bootstrapper, which applies the DISA STIG.",
-    "Parameters"               : {
-        "BootstrapURL" : {
+    "Description" : "This templates creates an Autoscaling Group and Launch Configuration that deploy RHEL6 instances with the SystemPrep bootstrapper, which applies the DISA STIG.",
+    "Parameters" :
+    {
+        "BootstrapURL" :
+        {
             "Description" : "URL to the SystemPrep Bootstrapper",
-            "Type"        : "String",
-            "Default"     : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Linux.sh"
+            "Type" : "String",
+            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Linux.sh"
         },
-        "KeyPairName" : {
+        "KeyPairName" :
+        {
             "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
-            "Type"        : "AWS::EC2::KeyPair::KeyName"
+            "Type" : "AWS::EC2::KeyPair::KeyName"
         },
-        "InstanceType" : {
+        "InstanceType" :
+        {
             "Description" : "Amazon EC2 instance type",
-            "Type"        : "String",
-            "Default"     : "t2.micro",
-            "AllowedValues" : [
+            "Type" : "String",
+            "Default" : "t2.micro",
+            "AllowedValues" :
+            [
                 "t2.micro",
                 "t2.small",
                 "t2.medium",
@@ -25,103 +30,86 @@
                 "m4.xlarge"
             ]
         },
-        "MinSize" : { 
+        "MinSize" :
+        {
             "Description" : "Minimum number of instances in the Autoscaling Group",
-            "Type"        : "Number",
+            "Type" : "Number",
             "Default" : "1"
         },
-        "MaxSize" : { 
+        "MaxSize" :
+        {
             "Description" : "Maximum number of instances in the Autoscaling Group",
-            "Type"        : "Number",
+            "Type" : "Number",
             "Default" : "1"
         },
-        "DesiredCapacity" : { 
+        "DesiredCapacity" :
+        {
             "Description" : "Desired number of instances in the Autoscaling Group",
-            "Type"        : "Number",
+            "Type" : "Number",
             "Default" : "1"
         },
-        "SecurityGroupIds" : {
+        "SecurityGroupIds" :
+        {
             "Description" : "List of security groups to apply to the instance",
-            "Type"        : "List<AWS::EC2::SecurityGroup::Id>"
+            "Type" : "List<AWS::EC2::SecurityGroup::Id>"
         },
-        "SubnetIds" : {
+        "SubnetIds" :
+        {
             "Type" : "List<AWS::EC2::Subnet::Id>",
             "Description" : "List of subnets to associate to the Autoscaling Group"
         }
     },
-    "Mappings" : {
-        "AWSInstanceType2Arch" : {
-            "t2.micro" : {
-                "Arch" : "64"
-            },
-            "t2.small" : {
-                "Arch" : "64"
-            },
-            "t2.medium" : {
-                "Arch" : "64"
-            },
-            "c4.large" : {
-                "Arch" : "64"
-            },
-            "c4.xlarge" : {
-                "Arch" : "64"
-            },
-            "m4.large" : {
-                "Arch" : "64"
-            },
-            "m4.xlarge" : {
-                "Arch" : "64"
-            }
+    "Mappings" :
+    {
+        "AWSInstanceType2Arch" :
+        {
+            "t2.micro" : { "Arch" : "64" },
+            "t2.small" : { "Arch" : "64" },
+            "t2.medium" : { "Arch" : "64" },
+            "c4.large" : { "Arch" : "64" },
+            "c4.xlarge" : { "Arch" : "64" },
+            "m4.large" : { "Arch" : "64" },
+            "m4.xlarge" : { "Arch" : "64" }
         },
-        "AWSRegionArch2AMI" : {
-            "us-east-1" : {
-                "64" : "ami-0d28fe66"
-            },
-            "us-west-2" : {
-                "64" : "ami-75f3f145"
-            },
-            "us-west-1" : {
-                "64" : "ami-5b8a781f"
-            },
-            "eu-west-1" : {
-                "64" : "ami-78d29c0f"
-            },
-            "eu-central-1" : {
-                "64" : "ami-8e96ac93"
-            },
-            "ap-southeast-1" : {
-                "64" : "ami-faedeea8"
-            },
-            "ap-northeast-1" : {
-                "64" : "ami-78379d78"
-            },
-            "ap-southeast-2" : {
-                "64" : "ami-7f0d4b45"
-            },
-            "sa-east-1" : {
-                "64" : "ami-d1d35ccc"
-            }
+        "AWSRegionArch2AMI" :
+        {
+            "us-east-1" : { "64" : "ami-0d28fe66" },
+            "us-west-2" : { "64" : "ami-75f3f145" },
+            "us-west-1" : { "64" : "ami-5b8a781f" },
+            "eu-west-1" : { "64" : "ami-78d29c0f" },
+            "eu-central-1" : { "64" : "ami-8e96ac93" },
+            "ap-southeast-1" : { "64" : "ami-faedeea8" },
+            "ap-northeast-1" : { "64" : "ami-78379d78" },
+            "ap-southeast-2" : { "64" : "ami-7f0d4b45" },
+            "sa-east-1" : { "64" : "ami-d1d35ccc" }
         }
     },
-    "Resources" : {
-        "SystemPrepAutoScalingGroup" : {
+    "Resources" :
+    {
+        "SystemPrepAutoScalingGroup" :
+        {
             "Type" : "AWS::AutoScaling::AutoScalingGroup",
-            "CreationPolicy" : {
-                "ResourceSignal" : {
+            "CreationPolicy" :
+            {
+                "ResourceSignal" :
+                {
                     "Count" : "1",
                     "Timeout" : "PT20M"
                 }
             },
-            "Properties" : {
+            "Properties" :
+            {
                 "VPCZoneIdentifier" : { "Ref" : "SubnetIds" },
                 "LaunchConfigurationName" : { "Ref" : "SystemPrepLaunchConfig" },
                 "MinSize" : { "Ref" : "MinSize" },
                 "MaxSize" : { "Ref" : "MaxSize" },
                 "DesiredCapacity" : { "Ref" : "DesiredCapacity" },
-                "Tags" : [
+                "Tags" :
+                [
                     {
                         "Key" : "Name",
-                        "Value" : { "Fn::Join" : [ "", [
+                        "Value" :
+                        { "Fn::Join" : [ "", [
                             "SystemPrep-Linux-",
                             { "Ref" : "AWS::StackName" }
                         ] ] },
@@ -130,17 +118,22 @@
                 ]
             }
         },
-        "SystemPrepLaunchConfig" : {
+        "SystemPrepLaunchConfig" :
+        {
             "Type" : "AWS::AutoScaling::LaunchConfiguration",
-            "Properties" : {
-                "ImageId" : {
-                    "Fn::FindInMap" : [
+            "Properties" :
+            {
+                "ImageId" :
+                {
+                    "Fn::FindInMap" :
+                    [
                         "AWSRegionArch2AMI",
                         {
                             "Ref" : "AWS::Region"
                         },
                         {
-                            "Fn::FindInMap" : [
+                            "Fn::FindInMap" :
+                            [
                                 "AWSInstanceType2Arch",
                                 {
                                     "Ref" : "InstanceType"
@@ -150,27 +143,34 @@
                         }
                     ]
                 },
-                "InstanceType" : {
+                "InstanceType" :
+                {
                     "Ref" : "InstanceType"
                 },
                 "AssociatePublicIpAddress" : "true",
-                "BlockDeviceMappings" : [
+                "BlockDeviceMappings" :
+                [
                     {
                         "DeviceName" : "/dev/sda1",
-                        "Ebs"        : {
-							"VolumeType" : "gp2",
+                        "Ebs" :
+                        {
+                            "VolumeType" : "gp2",
                             "DeleteOnTermination" : "true"
                         }
                     }
                 ],
-                "KeyName" : {
+                "KeyName" :
+                {
                     "Ref" : "KeyPairName"
                 },
-                "SecurityGroups" : { 
-                    "Ref" : "SecurityGroupIds" 
+                "SecurityGroups" :
+                {
+                    "Ref" : "SecurityGroupIds"
                 },
-                "UserData" : {
-                    "Fn::Base64" : { "Fn::Join" : [ "", [
+                "UserData" :
+                {
+                    "Fn::Base64" :
+                    { "Fn::Join" : [ "", [
                         "#!/bin/bash -x\n",
 
                         "curl --silent --show-error --retry 5 -L ",

--- a/Utils/cfn/systemprep-lx-instance.template
+++ b/Utils/cfn/systemprep-lx-instance.template
@@ -1,12 +1,13 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description" : "This templates deploys a Linux instance with the SystemPrep bootstrapper to apply the DISA STIG.",
+    "Description" : "This template deploys a Linux instance with the SystemPrep bootstrapper to apply the DISA STIG.",
     "Parameters" :
     {
         "AmiId" :
         {
             "Description" : "ID of the AMI to launch",
-            "Type" : "String"
+            "Type" : "String",
+            "AllowedPattern" : "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$"
         },
         "AmiDistro" :
         {
@@ -15,15 +16,32 @@
             "AllowedValues" :
             [
                 "AmazonLinux",
-                "RedHat",
-                "CentOS"
+                "CentOS",
+                "RedHat"
             ]
         },
-        "BootstrapURL" :
+        "AppScriptParams" :
         {
-            "Description" : "URL to the SystemPrep Bootstrapper",
+            "Description" : "Parameter string to pass to the application script. This parameter is ignored unless \"AppScriptUrl\" is provided",
+            "Type" : "String"
+        },
+        "AppScriptShell" :
+        {
+            "Description" : "Shell with which to execute the application script. This parameter is ignored unless \"AppScriptUrl\" is provided",
             "Type" : "String",
-            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Linux.sh"
+            "Default" : "bash",
+            "AllowedValues" :
+            [
+                "bash",
+                "python"
+            ]
+        },
+        "AppScriptUrl" :
+        {
+            "Description" : "URL to the application script. Leave blank to launch without an application script",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^http://.*$|^https://.*$"
         },
         "KeyPairName" :
         {
@@ -40,10 +58,44 @@
                 "t2.micro",
                 "t2.small",
                 "t2.medium",
+                "t2.large",
                 "c4.large",
                 "c4.xlarge",
                 "m4.large",
                 "m4.xlarge"
+            ]
+        },
+        "NoPublicIp" :
+        {
+            "Description" : "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
+            "Type" : "String",
+            "Default" : "true",
+            "AllowedValues" :
+            [
+                "false",
+                "true"
+            ]
+        },
+        "NoReboot" :
+        {
+            "Description" : "Controls whether to reboot the instance as the last step of cfn-init execution",
+            "Type" : "String",
+            "Default" : "false",
+            "AllowedValues" :
+            [
+                "false",
+                "true"
+            ]
+        },
+        "NoUpdates" :
+        {
+            "Description" : "Controls whether to run yum update during a stack update (on the initial instance launch, SystemPrep _always_ installs updates)",
+            "Type" : "String",
+            "Default" : "false",
+            "AllowedValues" :
+            [
+                "false",
+                "true"
             ]
         },
         "SecurityGroupIds" :
@@ -55,6 +107,67 @@
         {
           "Type" : "AWS::EC2::Subnet::Id",
           "Description" : "ID of the subnet to assign to the instance"
+        },
+        "SystemPrepBootstrapUrl" :
+        {
+            "Description" : "URL to the SystemPrep Bootstrapper",
+            "Type" : "String",
+            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Linux.sh",
+            "AllowedPattern" : "^http://.*\\.sh$|^https://.*\\.sh$"
+        },
+        "SystemPrepEnvironment" :
+        {
+            "Description" : "Environment in which the instance is being deployed",
+            "Type" : "String",
+            "Default" : "false",
+            "AllowedValues" :
+            [
+                "false",
+                "dev",
+                "test",
+                "prod"
+            ]
+        },
+        "SystemPrepOuPath" :
+        {
+            "Description" : "DN of the OU to place the instance when joining a domain. If blank and \"SystemPrepEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"SystemPrepEnvironment\" is \"false\"",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^(OU=.+,)+(DC=.+)+$"
+        },
+        "ToggleCfnInitUpdate" :
+        {
+            "Description" : "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
+            "Type" : "String",
+            "Default" : "A",
+            "AllowedValues" :
+            [
+                "A",
+                "B"
+            ]
+        }
+    },
+    "Conditions" :
+    {
+        "ExecuteAppScript" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AppScriptUrl" }, "" ] } ]
+        },
+        "UseOuPath" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "SystemPrepOuPath" }, "" ] } ]
+        },
+        "InstallUpdates" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoUpdates" }, "true" ] } ]
+        },
+        "Reboot" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoReboot" }, "true" ] } ]
+        },
+        "AssignPublicIp" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoPublicIp" }, "true" ] } ]
         }
     },
     "Mappings" :
@@ -76,7 +189,247 @@
                 "ResourceSignal" :
                 {
                     "Count" : "1",
-                    "Timeout" : "PT20M"
+                    "Timeout" : "PT30M"
+                }
+            },
+            "Metadata" : {
+                "ToggleCfnInitUpdate" : { "Ref" : "ToggleCfnInitUpdate" },
+                "AWS::CloudFormation::Init" :
+                {
+                    "configSets" :
+                    {
+                        "launch" :
+                        [
+                            "setup",
+                            "systemprep-launch",
+                            {
+                                "Fn::If" :
+                                [
+                                    "ExecuteAppScript",
+                                    "make-app",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            "finalize",
+                            {
+                                "Fn::If" :
+                                [
+                                    "Reboot",
+                                    "reboot",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            }
+                        ],
+                        "update" :
+                        [
+                            "setup",
+                            {
+                                "Fn::If" :
+                                [
+                                    "InstallUpdates",
+                                    "install-updates",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            "systemprep-update",
+                            {
+                                "Fn::If" :
+                                [
+                                    "ExecuteAppScript",
+                                    "make-app",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            "finalize",
+                            {
+                                "Fn::If" :
+                                [
+                                    "Reboot",
+                                    "reboot",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            }
+                        ]
+                    },
+                    "setup" :
+                    {
+                        "files" :
+                        {
+                            "/etc/cfn/cfn-hup.conf" :
+                            {
+                                "content" :
+                                { "Fn::Join" : ["", [
+                                    "[main]\n",
+                                    "stack=", { "Ref" : "AWS::StackId" }, "\n",
+                                    "region=", { "Ref" : "AWS::Region" }, "\n",
+                                    "interval=1", "\n",
+                                    "verbose=true", "\n"
+                                ]]},
+                                "mode"    : "000400",
+                                "owner"   : "root",
+                                "group"   : "root"
+                            },
+                            "/etc/cfn/hooks.d/cfn-auto-reloader.conf" :
+                            {
+                                "content" :
+                                { "Fn::Join" : ["", [
+                                    "[cfn-auto-reloader-hook]\n",
+                                    "triggers=post.update\n",
+                                    "path=Resources.SystemPrepInstance.Metadata\n",
+                                    "action=/opt/aws/bin/cfn-init -v -c update",
+                                    " --stack ", { "Ref" : "AWS::StackName" },
+                                    " --resource SystemPrepInstance",
+                                    " --region ", { "Ref" : "AWS::Region" }, "\n",
+                                    "runas=root\n"
+                                ]]},
+                                "mode" : "000400",
+                                "owner" : "root",
+                                "group" : "root"
+                            },
+                            "/etc/cfn/scripts/systemprep-bootstrapper.sh" :
+                            {
+                                "source" : { "Ref" : "SystemPrepBootstrapUrl" },
+                                "mode" : "000700",
+                                "owner" : "root",
+                                "group" : "root"
+                            }
+                        },
+                        "services" :
+                        {
+                            "sysvinit" :
+                            {
+                                "cfn-hup" :
+                                {
+                                    "enabled" : "true",
+                                    "ensureRunning" : "true",
+                                    "files" :
+                                    [
+                                        "/etc/cfn/cfn-hup.conf",
+                                        "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "install-updates" :
+                    {
+                        "commands" :
+                        {
+                            "10-install-updates" :
+                            {
+                                "command" : "yum -y update"
+                            }
+                        }
+                    },
+                    "systemprep-launch" :
+                    {
+                        "commands" :
+                        {
+                            "10-systemprep-launch" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    "bash /etc/cfn/scripts/systemprep-bootstrapper.sh",
+                                    " --noreboot",
+                                    " --environment ",
+                                    { "Ref" : "SystemPrepEnvironment" },
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseOuPath",
+                                            { "Fn::Join" : [ "", [
+                                                " --oupath \"",
+                                                { "Ref" : "SystemPrepOuPath" },
+                                                "\""
+                                            ]]},
+                                            ""
+                                        ]
+                                    }
+                                ]]}
+                            }
+                        }
+                    },
+                    "systemprep-update" :
+                    {
+                        "commands" :
+                        {
+                            "10-systemprep-update" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    "bash /etc/cfn/scripts/systemprep-bootstrapper.sh",
+                                    " --saltstates None",
+                                    " --noreboot",
+                                    " --environment ",
+                                    { "Ref" : "SystemPrepEnvironment" },
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseOuPath",
+                                            { "Fn::Join" : [ "", [
+                                                " --oupath \"",
+                                                { "Ref" : "SystemPrepOuPath" },
+                                                "\""
+                                            ]]},
+                                            ""
+                                        ]
+                                    }
+                                ]]}
+                            }
+                        }
+                    },
+                    "make-app" :
+                    {
+                        "files" :
+                        {
+                            "/etc/cfn/scripts/make-app" :
+                            {
+                                "source" : { "Ref" : "AppScriptUrl" },
+                                "mode" : "000700",
+                                "owner" : "root",
+                                "group" : "root"
+                            }
+                        },
+                        "commands" :
+                        {
+                            "10-make-app" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    { "Ref" : "AppScriptShell" },
+                                    " /etc/cfn/scripts/make-app ",
+                                    { "Ref" : "AppScriptParams" }
+                                ]]}
+                            }
+                        }
+                    },
+                    "finalize" :
+                    {
+                        "commands" :
+                        {
+                            "10-signal-success" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    "/opt/aws/bin/cfn-signal -e 0",
+                                    " --stack ", { "Ref" : "AWS::StackName" },
+                                    " --resource SystemPrepInstance",
+                                    " --region ", { "Ref" : "AWS::Region"}, "\n"
+                                ]]},
+                                "ignoreErrors" : "true"
+                            }
+                        }
+                    },
+                    "reboot" :
+                    {
+                        "commands" :
+                        {
+                            "10-reboot" :
+                            {
+                                "command" : "shutdown -r +1 &"
+                            }
+                        }
+                    }
                 }
             },
             "Properties" :
@@ -89,7 +442,6 @@
                         "Key" : "Name",
                         "Value" :
                         { "Fn::Join" : [ "", [
-                            "SystemPrep-Linux-",
                             { "Ref" : "AWS::StackName" }
                         ]]}
                     }
@@ -119,38 +471,47 @@
                 {
                     "Ref" : "KeyPairName"
                 },
-                "SecurityGroupIds" :
-                {
-                    "Ref" : "SecurityGroupIds"
-                },
-                "SubnetId" :
-                {
-                    "Ref" : "SubnetId"
-                },
+                "NetworkInterfaces":
+                [
+                    {
+                        "DeviceIndex" : "0",
+                        "AssociatePublicIpAddress" :
+                        {
+                            "Fn::If" :
+                            [
+                                "AssignPublicIp",
+                                "true",
+                                "false"
+                            ]
+                        },
+                        "GroupSet" : { "Ref": "SecurityGroupIds" },
+                        "SubnetId": { "Ref" : "SubnetId" }
+                    }
+                ],
                 "UserData" :
                 {
                     "Fn::Base64" :
                     { "Fn::Join" : [ "", [
-                        "#!/bin/bash -x\n",
+                        "#!/bin/bash -xe\n\n",
 
                         "# Get pip\n",
                         "curl --silent --show-error --retry 5 -L ",
                         "https://bootstrap.pypa.io/get-pip.py",
-                        " | python", "\n",
+                        " | python", "\n\n",
 
                         "# Add pip to path\n",
                         "hash pip 2> /dev/null || ",
-                        "PATH=\"${PATH}:/usr/local/bin\"", "\n",
+                        "PATH=\"${PATH}:/usr/local/bin\"", "\n\n",
 
                         "# Upgrade setuptools\n",
-                        "pip install --upgrade setuptools\n",
+                        "pip install --upgrade setuptools\n\n",
 
                         "# Fix python urllib3 warnings\n",
                         "yum -y install gcc python-devel libffi-devel openssl-devel\n",
-                        "pip install pyopenssl ndg-httpsclient pyasn1\n",
+                        "pip install pyopenssl ndg-httpsclient pyasn1\n\n",
 
                         "# Get cfn utils\n",
-                        "pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n",
+                        "pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n\n",
 
                         "# Remove gcc now that it is no longer needed\n",
                         "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
@@ -170,26 +531,25 @@
                         "do\n",
                         "    ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
                         "    echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
-                        "done\n",
+                        "done\n\n",
 
                         "# Add cfn-signal to path\n",
                         "hash cfn-signal 2> /dev/null || ",
                         "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
-                        "\n",
+                        "\n\n",
 
-                        "# Execute SystemPrep Bootstrapper\n",
-                        "curl --silent --show-error --retry 5 -L ",
-                        {
-                            "Ref" : "BootstrapURL"
-                        },
-                        " | bash", "\n",
-                        "result=$?", "\n",
-
-                        "# Signal completion to CloudFormation\n",
-                        "cfn-signal -e $result ",
+                        "# Execute cfn-init\n",
+                        "/opt/aws/bin/cfn-init -v -c launch",
                         " --stack ", { "Ref" : "AWS::StackName" },
-                        " --resource SystemPrepInstance ",
-                        " --region ", { "Ref" : "AWS::Region"}, "\n"
+                        " --resource SystemPrepInstance",
+                        " --region ", { "Ref" : "AWS::Region" }, " ||",
+                        " ( echo 'ERROR: cfn-init failed! Aborting!';",
+                        " /opt/aws/bin/cfn-signal -e 1",
+                        "  --stack ", { "Ref" : "AWS::StackName" },
+                        "  --resource SystemPrepInstance",
+                        "  --region ", { "Ref" : "AWS::Region"}, ";",
+                        " exit 1",
+                        " )\n\n"
                     ] ] }
                 }
             }

--- a/Utils/cfn/systemprep-lx-instance.template
+++ b/Utils/cfn/systemprep-lx-instance.template
@@ -55,7 +55,7 @@
         },
         "AWSRegionArch2AMI" :
         {
-            "us-east-1" : { "64" : "ami-0d28fe66" },
+            "us-east-1" : { "64" : "ami-60b6c60a" },
             "us-west-2" : { "64" : "ami-75f3f145" },
             "us-west-1" : { "64" : "ami-5b8a781f" },
             "eu-west-1" : { "64" : "ami-78d29c0f" },
@@ -119,7 +119,7 @@
                 "BlockDeviceMappings" :
                 [
                     {
-                        "DeviceName" : "/dev/sda1",
+                        "DeviceName" : "/dev/xvda",
                         "Ebs" :
                         {
                             "VolumeType" : "gp2",
@@ -145,29 +145,59 @@
                     { "Fn::Join" : [ "", [
                         "#!/bin/bash -x\n",
 
+                        "# Get pip\n",
                         "curl --silent --show-error --retry 5 -L ",
                         "https://bootstrap.pypa.io/get-pip.py",
                         " | python", "\n",
 
+                        "# Add pip to path\n",
                         "hash pip 2> /dev/null || ",
                         "PATH=\"${PATH}:/usr/local/bin\"", "\n",
 
-                        "pip install ",
-                        "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
-                        "\n",
+                        "# Upgrade setuptools\n",
+                        "pip install --upgrade setuptools\n",
 
+                        "# Fix python urllib3 warnings\n",
+                        "yum -y install gcc python-devel libffi-devel openssl-devel\n",
+                        "pip install pyopenssl ndg-httpsclient pyasn1\n",
+
+                        "# Get cfn utils\n",
+                        "pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n",
+
+                        "# Remove gcc now that it is no longer needed\n",
+                        "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
+
+                        "# Fixup cfn utils\n",
+                        "INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat ",
+                        "2> /dev/null || echo /usr/init/redhat)\n",
+                        "chmod 775 ${INITDIR}/cfn-hup\n",
+                        "ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
+                        "chkconfig --add cfn-hup\n",
+                        "chkconfig cfn-hup on\n",
+                        "mkdir -p /opt/aws/bin\n",
+                        "BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin ",
+                        "2> /dev/null || echo /usr/bin)\n",
+                        "for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup ",
+                        "cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
+                        "do\n",
+                        "    ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
+                        "    echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
+                        "done\n",
+
+                        "# Add cfn-signal to path\n",
                         "hash cfn-signal 2> /dev/null || ",
                         "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
                         "\n",
 
+                        "# Execute SystemPrep Bootstrapper\n",
                         "curl --silent --show-error --retry 5 -L ",
                         {
                             "Ref" : "BootstrapURL"
                         },
                         " | bash", "\n",
-
                         "result=$?", "\n",
 
+                        "# Signal completion to CloudFormation\n",
                         "cfn-signal -e $result ",
                         " --stack ", { "Ref" : "AWS::StackName" },
                         " --resource SystemPrepInstance ",

--- a/Utils/cfn/systemprep-lx-instance.template
+++ b/Utils/cfn/systemprep-lx-instance.template
@@ -1,8 +1,24 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description" : "This templates deploys a RHEL6 instance with the SystemPrep bootstrapper to apply the DISA STIG.",
+    "Description" : "This templates deploys a Linux instance with the SystemPrep bootstrapper to apply the DISA STIG.",
     "Parameters" :
     {
+        "AmiId" :
+        {
+            "Description" : "ID of the AMI to launch",
+            "Type" : "String"
+        },
+        "AmiDistro" :
+        {
+            "Description" : "Linux distro of the AMI",
+            "Type" : "String",
+            "AllowedValues" :
+            [
+                "AmazonLinux",
+                "RedHat",
+                "CentOS"
+            ]
+        },
         "BootstrapURL" :
         {
             "Description" : "URL to the SystemPrep Bootstrapper",
@@ -43,27 +59,11 @@
     },
     "Mappings" :
     {
-        "AWSInstanceType2Arch" :
+        "Distro2RootDevice" :
         {
-            "t2.micro" : { "Arch" : "64" },
-            "t2.small" : { "Arch" : "64" },
-            "t2.medium" : { "Arch" : "64" },
-            "c4.large" : { "Arch" : "64" },
-            "c4.xlarge" : { "Arch" : "64" },
-            "m4.large" : { "Arch" : "64" },
-            "m4.xlarge" : { "Arch" : "64" }
-        },
-        "AWSRegionArch2AMI" :
-        {
-            "us-east-1" : { "64" : "ami-60b6c60a" },
-            "us-west-2" : { "64" : "ami-75f3f145" },
-            "us-west-1" : { "64" : "ami-5b8a781f" },
-            "eu-west-1" : { "64" : "ami-78d29c0f" },
-            "eu-central-1" : { "64" : "ami-8e96ac93" },
-            "ap-southeast-1" : { "64" : "ami-faedeea8" },
-            "ap-northeast-1" : { "64" : "ami-78379d78" },
-            "ap-southeast-2" : { "64" : "ami-7f0d4b45" },
-            "sa-east-1" : { "64" : "ami-d1d35ccc" }
+            "AmazonLinux" : { "DeviceName" : "xvda" },
+            "RedHat" : { "DeviceName" : "sda1" },
+            "CentOS" : { "DeviceName" : "sda1" }
         }
     },
     "Resources" :
@@ -81,30 +81,8 @@
             },
             "Properties" :
             {
-                "ImageId" :
-                {
-                    "Fn::FindInMap" :
-                    [
-                        "AWSRegionArch2AMI",
-                        {
-                            "Ref" : "AWS::Region"
-                        },
-                        {
-                            "Fn::FindInMap" :
-                            [
-                                "AWSInstanceType2Arch",
-                                {
-                                    "Ref" : "InstanceType"
-                                },
-                                "Arch"
-                            ]
-                        }
-                    ]
-                },
-                "InstanceType" :
-                {
-                    "Ref" : "InstanceType"
-                },
+                "ImageId" : { "Ref" : "AmiId" },
+                "InstanceType" : { "Ref" : "InstanceType" },
                 "Tags" :
                 [
                     {
@@ -119,7 +97,17 @@
                 "BlockDeviceMappings" :
                 [
                     {
-                        "DeviceName" : "/dev/xvda",
+                        "DeviceName" :
+                        { "Fn::Join" : [ "", [
+                            "/dev/",
+                            { "Fn::FindInMap" :
+                                [
+                                    "Distro2RootDevice",
+                                    { "Ref" : "AmiDistro" },
+                                    "DeviceName"
+                                ]
+                            }
+                        ]]},
                         "Ebs" :
                         {
                             "VolumeType" : "gp2",

--- a/Utils/cfn/systemprep-lx-instance.template
+++ b/Utils/cfn/systemprep-lx-instance.template
@@ -1,21 +1,26 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description"              : "This templates deploys a RHEL6 instance with the SystemPrep bootstrapper to apply the DISA STIG.",
-    "Parameters"               : {
-        "BootstrapURL" : {
+    "Description" : "This templates deploys a RHEL6 instance with the SystemPrep bootstrapper to apply the DISA STIG.",
+    "Parameters" :
+    {
+        "BootstrapURL" :
+        {
             "Description" : "URL to the SystemPrep Bootstrapper",
-            "Type"        : "String",
-            "Default"     : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Linux.sh"
+            "Type" : "String",
+            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Linux.sh"
         },
-        "KeyPairName" : {
+        "KeyPairName" :
+        {
             "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
-            "Type"        : "AWS::EC2::KeyPair::KeyName"
+            "Type" : "AWS::EC2::KeyPair::KeyName"
         },
-        "InstanceType" : {
+        "InstanceType" :
+        {
             "Description" : "Amazon EC2 instance type",
-            "Type"        : "String",
-            "Default"     : "t2.micro",
-            "AllowedValues" : [
+            "Type" : "String",
+            "Default" : "t2.micro",
+            "AllowedValues" :
+            [
                 "t2.micro",
                 "t2.small",
                 "t2.medium",
@@ -25,87 +30,68 @@
                 "m4.xlarge"
             ]
         },
-        "SecurityGroupIds" : {
+        "SecurityGroupIds" :
+        {
             "Description" : "List of security groups to apply to the instance",
-            "Type"        : "List<AWS::EC2::SecurityGroup::Id>"
+            "Type" : "List<AWS::EC2::SecurityGroup::Id>"
         },
-            "SubnetId" : {
-              "Type" : "AWS::EC2::Subnet::Id",
-              "Description" : "ID of the subnet to assign to the instance"
+        "SubnetId" :
+        {
+          "Type" : "AWS::EC2::Subnet::Id",
+          "Description" : "ID of the subnet to assign to the instance"
         }
     },
-    "Mappings" : {
-        "AWSInstanceType2Arch" : {
-            "t2.micro" : {
-                "Arch" : "64"
-            },
-            "t2.small" : {
-                "Arch" : "64"
-            },
-            "t2.medium" : {
-                "Arch" : "64"
-            },
-            "c4.large" : {
-                "Arch" : "64"
-            },
-            "c4.xlarge" : {
-                "Arch" : "64"
-            },
-            "m4.large" : {
-                "Arch" : "64"
-            },
-            "m4.xlarge" : {
-                "Arch" : "64"
-            }
+    "Mappings" :
+    {
+        "AWSInstanceType2Arch" :
+        {
+            "t2.micro" : { "Arch" : "64" },
+            "t2.small" : { "Arch" : "64" },
+            "t2.medium" : { "Arch" : "64" },
+            "c4.large" : { "Arch" : "64" },
+            "c4.xlarge" : { "Arch" : "64" },
+            "m4.large" : { "Arch" : "64" },
+            "m4.xlarge" : { "Arch" : "64" }
         },
-        "AWSRegionArch2AMI" : {
-            "us-east-1" : {
-                "64" : "ami-0d28fe66"
-            },
-            "us-west-2" : {
-                "64" : "ami-75f3f145"
-            },
-            "us-west-1" : {
-                "64" : "ami-5b8a781f"
-            },
-            "eu-west-1" : {
-                "64" : "ami-78d29c0f"
-            },
-            "eu-central-1" : {
-                "64" : "ami-8e96ac93"
-            },
-            "ap-southeast-1" : {
-                "64" : "ami-faedeea8"
-            },
-            "ap-northeast-1" : {
-                "64" : "ami-78379d78"
-            },
-            "ap-southeast-2" : {
-                "64" : "ami-7f0d4b45"
-            },
-            "sa-east-1" : {
-                "64" : "ami-d1d35ccc"
-            }
+        "AWSRegionArch2AMI" :
+        {
+            "us-east-1" : { "64" : "ami-0d28fe66" },
+            "us-west-2" : { "64" : "ami-75f3f145" },
+            "us-west-1" : { "64" : "ami-5b8a781f" },
+            "eu-west-1" : { "64" : "ami-78d29c0f" },
+            "eu-central-1" : { "64" : "ami-8e96ac93" },
+            "ap-southeast-1" : { "64" : "ami-faedeea8" },
+            "ap-northeast-1" : { "64" : "ami-78379d78" },
+            "ap-southeast-2" : { "64" : "ami-7f0d4b45" },
+            "sa-east-1" : { "64" : "ami-d1d35ccc" }
         }
     },
-    "Resources" : {
-        "SystemPrepInstance" : {
+    "Resources" :
+    {
+        "SystemPrepInstance" :
+        {
             "Type" : "AWS::EC2::Instance",
-            "CreationPolicy" : {
-                "ResourceSignal" : {
+            "CreationPolicy" :
+            {
+                "ResourceSignal" :
+                {
                     "Count" : "1",
                     "Timeout" : "PT20M"
                 }
             },
-            "Properties" : {
-                "ImageId" : {
-                    "Fn::FindInMap" : [
+            "Properties" :
+            {
+                "ImageId" :
+                {
+                    "Fn::FindInMap" :
+                    [
                         "AWSRegionArch2AMI",
                         {
                             "Ref" : "AWS::Region"
                         },
                         {
-                            "Fn::FindInMap" : [
+                            "Fn::FindInMap" :
+                            [
                                 "AWSInstanceType2Arch",
                                 {
                                     "Ref" : "InstanceType"
@@ -115,38 +101,48 @@
                         }
                     ]
                 },
-                "InstanceType" : {
+                "InstanceType" :
+                {
                     "Ref" : "InstanceType"
                 },
-                "Tags" : [
+                "Tags" :
+                [
                     {
                         "Key" : "Name",
-                        "Value" : { "Fn::Join" : [ "", [
+                        "Value" :
+                        { "Fn::Join" : [ "", [
                             "SystemPrep-Linux-",
                             { "Ref" : "AWS::StackName" }
                         ]]}
                     }
                 ],
-                "BlockDeviceMappings" : [
+                "BlockDeviceMappings" :
+                [
                     {
                         "DeviceName" : "/dev/sda1",
-                        "Ebs"        : {
-							"VolumeType" : "gp2",
+                        "Ebs" :
+                        {
+                            "VolumeType" : "gp2",
                             "DeleteOnTermination" : "true"
                         }
                     }
                 ],
-                "KeyName" : {
+                "KeyName" :
+                {
                     "Ref" : "KeyPairName"
                 },
-                "SecurityGroupIds" : { 
-                    "Ref" : "SecurityGroupIds" 
+                "SecurityGroupIds" :
+                {
+                    "Ref" : "SecurityGroupIds"
                 },
-                "SubnetId" : { 
-                    "Ref" : "SubnetId" 
+                "SubnetId" :
+                {
+                    "Ref" : "SubnetId"
                 },
-                "UserData" : {
-                    "Fn::Base64" : { "Fn::Join" : [ "", [
+                "UserData" :
+                {
+                    "Fn::Base64" :
+                    { "Fn::Join" : [ "", [
                         "#!/bin/bash -x\n",
 
                         "curl --silent --show-error --retry 5 -L ",
@@ -181,11 +177,11 @@
             }
         }
     },
-    "Outputs" : {
-        "SystemPrepInstanceId" : {
-            "Value" : {
-                "Ref" : "SystemPrepInstance"
-            },
+    "Outputs" :
+    {
+        "SystemPrepInstanceId" :
+        {
+            "Value" : { "Ref" : "SystemPrepInstance" },
             "Description" : "Instance ID"
         }
     }

--- a/Utils/cfn/systemprep-win-autoscale.template
+++ b/Utils/cfn/systemprep-win-autoscale.template
@@ -1,21 +1,26 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description"              : "This template creates an Autoscaling Group and Launch Configuration that deploy Windows 2012 R2 instances with the SystemPrep bootstrapper, which applies the DISA STIG.",
-    "Parameters"               : {
-        "BootstrapURL" : {
+    "Description" : "This template creates an Autoscaling Group and Launch Configuration that deploy Windows 2012 R2 instances with the SystemPrep bootstrapper, which applies the DISA STIG.",
+    "Parameters" :
+    {
+        "BootstrapURL" :
+        {
             "Description" : "URL to the SystemPrep Bootstrapper",
-            "Type"        : "String",
-            "Default"     : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1"
+            "Type" : "String",
+            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1"
         },
-        "KeyPairName" : {
+        "KeyPairName" :
+        {
             "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
-            "Type"        : "AWS::EC2::KeyPair::KeyName"
+            "Type" : "AWS::EC2::KeyPair::KeyName"
         },
-        "InstanceType" : {
+        "InstanceType" :
+        {
             "Description" : "Amazon EC2 instance type",
-            "Type"        : "String",
-            "Default"     : "t2.micro",
-            "AllowedValues" : [
+            "Type" : "String",
+            "Default" : "t2.micro",
+            "AllowedValues" :
+            [
                 "t2.micro",
                 "t2.small",
                 "t2.medium",
@@ -25,103 +30,86 @@
                 "m4.xlarge"
             ]
         },
-        "MinSize" : { 
+        "MinSize" :
+        {
             "Description" : "Minimum number of instances in the Autoscaling Group",
-            "Type"        : "Number",
+            "Type" : "Number",
             "Default" : "1"
         },
-        "MaxSize" : { 
+        "MaxSize" :
+        {
             "Description" : "Maximum number of instances in the Autoscaling Group",
-            "Type"        : "Number",
+            "Type" : "Number",
             "Default" : "1"
         },
-        "DesiredCapacity" : { 
+        "DesiredCapacity" :
+        {
             "Description" : "Desired number of instances in the Autoscaling Group",
-            "Type"        : "Number",
+            "Type" : "Number",
             "Default" : "1"
         },
-        "SecurityGroupIds" : {
+        "SecurityGroupIds" :
+        {
             "Description" : "List of security groups to apply to the instance",
-            "Type"        : "List<AWS::EC2::SecurityGroup::Id>"
+            "Type" : "List<AWS::EC2::SecurityGroup::Id>"
         },
-        "SubnetIds" : {
+        "SubnetIds" :
+        {
             "Type" : "List<AWS::EC2::Subnet::Id>",
             "Description" : "List of subnets to associate to the Autoscaling Group"
         }
     },
-    "Mappings" : {
-        "AWSInstanceType2Arch" : {
-            "t2.micro" : {
-                "Arch" : "64"
-            },
-            "t2.small" : {
-                "Arch" : "64"
-            },
-            "t2.medium" : {
-                "Arch" : "64"
-            },
-            "c4.large" : {
-                "Arch" : "64"
-            },
-            "c4.xlarge" : {
-                "Arch" : "64"
-            },
-            "m4.large" : {
-                "Arch" : "64"
-            },
-            "m4.xlarge" : {
-                "Arch" : "64"
-            }
+    "Mappings" :
+    {
+        "AWSInstanceType2Arch" :
+        {
+            "t2.micro" : { "Arch" : "64" },
+            "t2.small" : { "Arch" : "64" },
+            "t2.medium" : { "Arch" : "64" },
+            "c4.large" : { "Arch" : "64" },
+            "c4.xlarge" : { "Arch" : "64" },
+            "m4.large" : { "Arch" : "64" },
+            "m4.xlarge" : { "Arch" : "64" }
         },
-        "AWSRegionArch2AMI" : {
-            "us-east-1" : {
-                "64" : "ami-cd9339a6"
-            },
-            "us-west-2" : {
-                "64" : "ami-4dbcb67d"
-            },
-            "us-west-1" : {
-                "64" : "ami-bf2dd3fb"
-            },
-            "eu-west-1" : {
-                "64" : "ami-1a92cf6d"
-            },
-            "eu-central-1" : {
-                "64" : "ami-86393e9b"
-            },
-            "ap-southeast-1" : {
-                "64" : "ami-12737d40"
-            },
-            "ap-northeast-1" : {
-                "64" : "ami-b4ce74b4"
-            },
-            "ap-southeast-2" : {
-                "64" : "ami-7ddb9847"
-            },
-            "sa-east-1" : {
-                "64" : "ami-89ff7794"
-            }
+        "AWSRegionArch2AMI" :
+        {
+            "us-east-1" : { "64" : "ami-cd9339a6" },
+            "us-west-2" : { "64" : "ami-4dbcb67d" },
+            "us-west-1" : { "64" : "ami-bf2dd3fb" },
+            "eu-west-1" : { "64" : "ami-1a92cf6d" },
+            "eu-central-1" : { "64" : "ami-86393e9b" },
+            "ap-southeast-1" : { "64" : "ami-12737d40" },
+            "ap-northeast-1" : { "64" : "ami-b4ce74b4" },
+            "ap-southeast-2" : { "64" : "ami-7ddb9847" },
+            "sa-east-1" : { "64" : "ami-89ff7794" }
         }
     },
-    "Resources" : {
-        "SystemPrepAutoScalingGroup" : {
+    "Resources" :
+    {
+        "SystemPrepAutoScalingGroup" :
+        {
             "Type" : "AWS::AutoScaling::AutoScalingGroup",
-            "CreationPolicy" : {
-                "ResourceSignal" : {
+            "CreationPolicy" :
+            {
+                "ResourceSignal" :
+                {
                     "Count" : "1",
                     "Timeout" : "PT20M"
                 }
             },
-            "Properties" : {
+            "Properties" :
+            {
                 "VPCZoneIdentifier" : { "Ref" : "SubnetIds" },
                 "LaunchConfigurationName" : { "Ref" : "SystemPrepLaunchConfig" },
                 "MinSize" : { "Ref" : "MinSize" },
                 "MaxSize" : { "Ref" : "MaxSize" },
                 "DesiredCapacity" : { "Ref" : "DesiredCapacity" },
-                "Tags" : [
+                "Tags" :
+                [
                     {
                         "Key" : "Name",
-                        "Value" : { "Fn::Join" : [ "", [
+                        "Value" :
+                        { "Fn::Join" : [ "", [
                             "SystemPrep-Windows-",
                             { "Ref" : "AWS::StackName" }
                         ] ] },
@@ -130,17 +118,22 @@
                 ]
             }
         },
-        "SystemPrepLaunchConfig" : {
+        "SystemPrepLaunchConfig" :
+        {
             "Type" : "AWS::AutoScaling::LaunchConfiguration",
-            "Properties" : {
-                "ImageId" : {
-                    "Fn::FindInMap" : [
+            "Properties" :
+            {
+                "ImageId" :
+                {
+                    "Fn::FindInMap" :
+                    [
                         "AWSRegionArch2AMI",
                         {
                             "Ref" : "AWS::Region"
                         },
                         {
-                            "Fn::FindInMap" : [
+                            "Fn::FindInMap" :
+                            [
                                 "AWSInstanceType2Arch",
                                 {
                                     "Ref" : "InstanceType"
@@ -150,27 +143,34 @@
                         }
                     ]
                 },
-                "InstanceType" : {
+                "InstanceType" :
+                {
                     "Ref" : "InstanceType"
                 },
                 "AssociatePublicIpAddress" : "true",
-                "BlockDeviceMappings" : [
+                "BlockDeviceMappings" :
+                [
                     {
                         "DeviceName" : "/dev/sda1",
-                        "Ebs"        : {
+                        "Ebs" :
+                        {
                             "VolumeType" : "gp2",
                             "DeleteOnTermination" : "true"
                         }
                     }
                 ],
-                "KeyName" : {
+                "KeyName" :
+                {
                     "Ref" : "KeyPairName"
                 },
-                "SecurityGroups" : { 
-                    "Ref" : "SecurityGroupIds" 
+                "SecurityGroups" :
+                {
+                    "Ref" : "SecurityGroupIds"
                 },
-                "UserData" : {
-                    "Fn::Base64" : { "Fn::Join" : [ "", [
+                "UserData" :
+                {
+                    "Fn::Base64" :
+                    { "Fn::Join" : [ "", [
                         "<powershell>", "\n",
 
                         "Invoke-WebRequest -URI \"",

--- a/Utils/cfn/systemprep-win-autoscale.template
+++ b/Utils/cfn/systemprep-win-autoscale.template
@@ -1,8 +1,13 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description" : "This template creates an Autoscaling Group and Launch Configuration that deploy Windows 2012 R2 instances with the SystemPrep bootstrapper, which applies the DISA STIG.",
+    "Description" : "This template creates an Autoscaling Group and Launch Configuration that deploys Windows instances with the SystemPrep bootstrapper, which applies the DISA STIG.",
     "Parameters" :
     {
+        "AmiId" :
+        {
+            "Description" : "ID of the AMI to launch",
+            "Type" : "String"
+        },
         "BootstrapURL" :
         {
             "Description" : "URL to the SystemPrep Bootstrapper",
@@ -123,30 +128,8 @@
             "Type" : "AWS::AutoScaling::LaunchConfiguration",
             "Properties" :
             {
-                "ImageId" :
-                {
-                    "Fn::FindInMap" :
-                    [
-                        "AWSRegionArch2AMI",
-                        {
-                            "Ref" : "AWS::Region"
-                        },
-                        {
-                            "Fn::FindInMap" :
-                            [
-                                "AWSInstanceType2Arch",
-                                {
-                                    "Ref" : "InstanceType"
-                                },
-                                "Arch"
-                            ]
-                        }
-                    ]
-                },
-                "InstanceType" :
-                {
-                    "Ref" : "InstanceType"
-                },
+                "ImageId" : { "Ref" : "AmiId" },
+                "InstanceType" : { "Ref" : "InstanceType" },
                 "AssociatePublicIpAddress" : "true",
                 "BlockDeviceMappings" :
                 [

--- a/Utils/cfn/systemprep-win-autoscale.template
+++ b/Utils/cfn/systemprep-win-autoscale.template
@@ -6,13 +6,31 @@
         "AmiId" :
         {
             "Description" : "ID of the AMI to launch",
+            "Type" : "String",
+            "AllowedPattern" : "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$"
+        },
+        "AppScriptParams" :
+        {
+            "Description" : "Parameter string to pass to the application script. This parameter is ignored unless \"AppScriptUrl\" is provided",
             "Type" : "String"
         },
-        "BootstrapURL" :
+        "AppScriptShell" :
         {
-            "Description" : "URL to the SystemPrep Bootstrapper",
+            "Description" : "Shell with which to execute the application script. This parameter is ignored unless \"AppScriptUrl\" is provided",
             "Type" : "String",
-            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1"
+            "Default" : "powershell",
+            "AllowedValues" :
+            [
+                "cmd",
+                "powershell"
+            ]
+        },
+        "AppScriptUrl" :
+        {
+            "Description" : "URL to the application script. Leave blank to launch without an application script",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^http://.*$|^https://.*$"
         },
         "KeyPairName" :
         {
@@ -29,10 +47,33 @@
                 "t2.micro",
                 "t2.small",
                 "t2.medium",
+                "t2.large",
                 "c4.large",
                 "c4.xlarge",
                 "m4.large",
                 "m4.xlarge"
+            ]
+        },
+        "NoPublicIp" :
+        {
+            "Description" : "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
+            "Type" : "String",
+            "Default" : "true",
+            "AllowedValues" :
+            [
+                "false",
+                "true"
+            ]
+        },
+        "NoReboot" :
+        {
+            "Description" : "Controls whether to reboot the instance as the last step of cfn-init execution",
+            "Type" : "String",
+            "Default" : "false",
+            "AllowedValues" :
+            [
+                "false",
+                "true"
             ]
         },
         "MinSize" :
@@ -45,7 +86,7 @@
         {
             "Description" : "Maximum number of instances in the Autoscaling Group",
             "Type" : "Number",
-            "Default" : "1"
+            "Default" : "2"
         },
         "DesiredCapacity" :
         {
@@ -62,31 +103,88 @@
         {
             "Type" : "List<AWS::EC2::Subnet::Id>",
             "Description" : "List of subnets to associate to the Autoscaling Group"
+        },
+        "SystemPrepBootstrapUrl" :
+        {
+            "Description" : "URL to the SystemPrep Bootstrapper",
+            "Type" : "String",
+            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1",
+            "AllowedPattern" : "^http://.*\\.ps1$|^https://.*\\.ps1$"
+        },
+        "SystemPrepEnvironment" :
+        {
+            "Description" : "Environment in which the instance is being deployed",
+            "Type" : "String",
+            "Default" : "$false",
+            "AllowedValues" :
+            [
+                "$false",
+                "dev",
+                "test",
+                "prod"
+            ]
+        },
+        "SystemPrepOuPath" :
+        {
+            "Description" : "DN of the OU to place the instance when joining a domain. If blank and \"SystemPrepEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"SystemPrepEnvironment\" is \"$false\"",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^(OU=.+,)+(DC=.+)+$"
+        },
+        "ToggleCfnInitUpdate" :
+        {
+            "Description" : "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
+            "Type" : "String",
+            "Default" : "A",
+            "AllowedValues" :
+            [
+                "A",
+                "B"
+            ]
+        },
+        "ToggleNewInstances" :
+        {
+            "Description" : "A/B toggle that forces a change to instance userdata, triggering new instances via the Autoscale update policy",
+            "Type" : "String",
+            "Default" : "A",
+            "AllowedValues" :
+            [
+                "A",
+                "B"
+            ]
+        }
+    },
+    "Conditions" :
+    {
+        "ExecuteAppScript" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AppScriptUrl" }, "" ] } ]
+        },
+        "UseOuPath" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "SystemPrepOuPath" }, "" ] } ]
+        },
+        "Reboot" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoReboot" }, "true" ] } ]
+        },
+        "AssignPublicIp" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoPublicIp" }, "true" ] } ]
         }
     },
     "Mappings" :
     {
-        "AWSInstanceType2Arch" :
+        "ShellCommandMap" :
         {
-            "t2.micro" : { "Arch" : "64" },
-            "t2.small" : { "Arch" : "64" },
-            "t2.medium" : { "Arch" : "64" },
-            "c4.large" : { "Arch" : "64" },
-            "c4.xlarge" : { "Arch" : "64" },
-            "m4.large" : { "Arch" : "64" },
-            "m4.xlarge" : { "Arch" : "64" }
-        },
-        "AWSRegionArch2AMI" :
-        {
-            "us-east-1" : { "64" : "ami-cd9339a6" },
-            "us-west-2" : { "64" : "ami-4dbcb67d" },
-            "us-west-1" : { "64" : "ami-bf2dd3fb" },
-            "eu-west-1" : { "64" : "ami-1a92cf6d" },
-            "eu-central-1" : { "64" : "ami-86393e9b" },
-            "ap-southeast-1" : { "64" : "ami-12737d40" },
-            "ap-northeast-1" : { "64" : "ami-b4ce74b4" },
-            "ap-southeast-2" : { "64" : "ami-7ddb9847" },
-            "sa-east-1" : { "64" : "ami-89ff7794" }
+            "powershell" :
+            {
+                "command" : "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass"
+            },
+            "cmd" :
+            {
+                "command" : "cmd.exe"
+            }
         }
     },
     "Resources" :
@@ -94,12 +192,20 @@
         "SystemPrepAutoScalingGroup" :
         {
             "Type" : "AWS::AutoScaling::AutoScalingGroup",
+            "UpdatePolicy" : {
+                "AutoScalingRollingUpdate" : {
+                    "MinInstancesInService" : "1",
+                    "MaxBatchSize" : "2",
+                    "WaitOnResourceSignals" : "true",
+                    "PauseTime" : "PT60M"
+                }
+            },
             "CreationPolicy" :
             {
                 "ResourceSignal" :
                 {
-                    "Count" : "1",
-                    "Timeout" : "PT20M"
+                    "Count" : { "Ref" : "DesiredCapacity" },
+                    "Timeout" : "PT60M"
                 }
             },
             "Properties" :
@@ -115,7 +221,6 @@
                         "Key" : "Name",
                         "Value" :
                         { "Fn::Join" : [ "", [
-                            "SystemPrep-Windows-",
                             { "Ref" : "AWS::StackName" }
                         ] ] },
                         "PropagateAtLaunch" : "true"
@@ -126,6 +231,242 @@
         "SystemPrepLaunchConfig" :
         {
             "Type" : "AWS::AutoScaling::LaunchConfiguration",
+            "Metadata" : {
+                "ToggleCfnInitUpdate" : { "Ref" : "ToggleCfnInitUpdate" },
+                "AWS::CloudFormation::Init" :
+                {
+                    "configSets" :
+                    {
+                        "launch" :
+                        [
+                            "setup",
+                            "systemprep-launch",
+                            {
+                                "Fn::If" :
+                                [
+                                    "ExecuteAppScript",
+                                    "make-app",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            {
+                                "Fn::If" :
+                                [
+                                    "Reboot",
+                                    "reboot",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            "finalize"
+                        ],
+                        "update" :
+                        [
+                            "setup",
+                            "systemprep-update",
+                            {
+                                "Fn::If" :
+                                [
+                                    "ExecuteAppScript",
+                                    "make-app",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            {
+                                "Fn::If" :
+                                [
+                                    "Reboot",
+                                    "reboot",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            "finalize"
+                        ]
+                    },
+                    "setup" :
+                    {
+                        "files" :
+                        {
+                            "c:\\cfn\\cfn-hup.conf" :
+                            {
+                                "content" :
+                                { "Fn::Join" : ["", [
+                                    "[main]\n",
+                                    "stack=", { "Ref" : "AWS::StackId" }, "\n",
+                                    "region=", { "Ref" : "AWS::Region" }, "\n",
+                                    "interval=1", "\n",
+                                    "verbose=true", "\n"
+                                ]]}
+                            },
+                            "c:\\cfn\\hooks.d\\cfn-auto-reloader.conf" :
+                            {
+                                "content" :
+                                { "Fn::Join" : ["", [
+                                    "[cfn-auto-reloader-hook]\n",
+                                    "triggers=post.update\n",
+                                    "path=Resources.SystemPrepLaunchConfig.Metadata\n",
+                                    "action=cfn-init.exe -v -c update",
+                                    " --stack ", { "Ref" : "AWS::StackName" },
+                                    " --resource SystemPrepLaunchConfig",
+                                    " --region ", { "Ref" : "AWS::Region" }, "\n"
+                                ]]}
+                            },
+                            "c:\\cfn\\scripts\\systemprep-bootstrapper.ps1" :
+                            {
+                                "source" : { "Ref" : "SystemPrepBootstrapUrl" }
+                            }
+                        },
+                        "services" :
+                        {
+                            "windows" :
+                            {
+                                "cfn-hup" :
+                                {
+                                    "enabled" : "true",
+                                    "ensureRunning" : "true",
+                                    "files" :
+                                    [
+                                        "c:\\cfn\\cfn-hup.conf",
+                                        "c:\\cfn\\hooks.d\\cfn-auto-reloader.conf"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "systemprep-launch" :
+                    {
+                        "commands" :
+                        {
+                            "10-systemprep-launch" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    { "Fn::FindInMap" :
+                                        [
+                                            "ShellCommandMap",
+                                            "powershell",
+                                            "command"
+                                        ]
+                                    },
+                                    " c:\\cfn\\scripts\\systemprep-bootstrapper.ps1",
+                                    " -NoReboot \"$true\"",
+                                    " -EntEnv \"",
+                                    { "Ref" : "SystemPrepEnvironment" },
+                                    "\"",
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseOuPath",
+                                            { "Fn::Join" : [ "", [
+                                                " -OuPath \"",
+                                                { "Ref" : "SystemPrepOuPath" },
+                                                "\""
+                                            ]]},
+                                            ""
+                                        ]
+                                    }
+                                ]]},
+                                "waitAfterCompletion" : "0"
+                            }
+                        }
+                    },
+                    "systemprep-update" :
+                    {
+                        "commands" :
+                        {
+                            "10-systemprep-update" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    { "Fn::FindInMap" :
+                                        [
+                                            "ShellCommandMap",
+                                            "powershell",
+                                            "command"
+                                        ]
+                                    },
+                                    " c:\\cfn\\scripts\\systemprep-bootstrapper.ps1",
+                                    " -SaltStates None",
+                                    " -NoReboot \"$true\"",
+                                    " -EntEnv \"",
+                                    { "Ref" : "SystemPrepEnvironment" },
+                                    "\"",
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseOuPath",
+                                            { "Fn::Join" : [ "", [
+                                                " -OuPath \"",
+                                                { "Ref" : "SystemPrepOuPath" },
+                                                "\""
+                                            ]]},
+                                            ""
+                                        ]
+                                    }
+                                ]]},
+                                "waitAfterCompletion" : "0"
+                            }
+                        }
+                    },
+                    "make-app" :
+                    {
+                        "files" :
+                        {
+                            "c:\\cfn\\scripts\\make-app" :
+                            {
+                                "source" : { "Ref" : "AppScriptUrl" }
+                            }
+                        },
+                        "commands" :
+                        {
+                            "10-make-app" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    { "Fn::FindInMap" :
+                                        [
+                                            "ShellCommandMap",
+                                            { "Ref" : "AppScriptShell" },
+                                            "command"
+                                        ]
+                                    },
+                                    " c:\\cfn\\scripts\\make-app ",
+                                    { "Ref" : "AppScriptParams" }
+                                ]]},
+                                "waitAfterCompletion" : "0"
+                            }
+                        }
+                    },
+                    "reboot" :
+                    {
+                        "commands" :
+                        {
+                            "10-reboot" :
+                            {
+                                "command" : "powershell.exe \"Restart-Computer -Force -Verbose\"",
+                                "waitAfterCompletion" : "forever"
+                            }
+                        }
+                    },
+                    "finalize" :
+                    {
+                        "commands" :
+                        {
+                            "10-signal-success" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    "cfn-signal.exe -e 0",
+                                    " --stack ", { "Ref" : "AWS::StackName" },
+                                    " --resource SystemPrepAutoScalingGroup",
+                                    " --region ", { "Ref" : "AWS::Region"}, "\n"
+                                ]]},
+                                "ignoreErrors" : "true",
+                                "waitAfterCompletion" : "0"
+                            }
+                        }
+                    }
+                }
+            },
             "Properties" :
             {
                 "ImageId" : { "Ref" : "AmiId" },
@@ -154,31 +495,30 @@
                 {
                     "Fn::Base64" :
                     { "Fn::Join" : [ "", [
-                        "<powershell>", "\n",
+                        "<script>", "\n",
 
-                        "Invoke-WebRequest -URI \"",
-                        {
-                            "Ref" : "BootstrapURL"
-                        },
-                        "\" -OutFile .\\bootstrap.ps1", "\n",
+                        "REM CFN LaunchConfig Update Toggle: ",
+                        { "Ref" : "ToggleNewInstances" },
+                        "\n\n",
 
-                        "try { ", "\n",
-                        "  .\\bootstrap.ps1", "\n",
-                        "  cfn-signal.exe -e 0 ",
-                        "   --stack ", { "Ref" : "AWS::StackName" },
-                        "   --resource SystemPrepAutoScalingGroup ",
-                        "   --region ", { "Ref" : "AWS::Region" }, "\n",
-                        "}", "\n",
+                        "cfn-init.exe -v -c launch",
+                        " --stack ", { "Ref" : "AWS::StackName" },
+                        " --resource SystemPrepLaunchConfig ",
+                        " --region ", { "Ref" : "AWS::Region" }, "\n",
 
-                        "catch { ", "\n",
-                        "  cfn-signal.exe -e 1 ",
-                        "   --stack ", { "Ref" : "AWS::StackName" },
-                        "   --resource SystemPrepAutoScalingGroup ",
-                        "   --region ", { "Ref" : "AWS::Region" }, "\n",
-                        "  throw", "\n",
-                        "}", "\n",
+                        "if %ERRORLEVEL% equ 0 goto success\n\n",
 
-                        "</powershell>"
+                        ":error\n",
+                        "cfn-signal.exe -e 1",
+                        " --stack ", { "Ref" : "AWS::StackName" },
+                        " --resource SystemPrepAutoScalingGroup ",
+                        " --region ", { "Ref" : "AWS::Region" }, "\n",
+                        "echo \"ERROR: cfn-init failed! Aborting!\"", "\n",
+                        "exit /b 1\n\n",
+
+                        ":success\n",
+
+                        "</script>"
                     ] ] }
                 }
             }

--- a/Utils/cfn/systemprep-win-instance.template
+++ b/Utils/cfn/systemprep-win-instance.template
@@ -1,21 +1,26 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description"              : "This template deploys a Windows 2012 R2 instance with the SystemPrep bootstrapper to apply the DISA STIG.",
-    "Parameters"               : {
-        "BootstrapURL" : {
+    "Description" : "This template deploys a Windows 2012 R2 instance with the SystemPrep bootstrapper to apply the DISA STIG.",
+    "Parameters" :
+    {
+        "BootstrapURL" :
+        {
             "Description" : "URL to the SystemPrep Bootstrapper",
-            "Type"        : "String",
-            "Default"     : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1"
+            "Type" : "String",
+            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1"
         },
-        "KeyPairName" : {
+        "KeyPairName" :
+        {
             "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
-            "Type"        : "AWS::EC2::KeyPair::KeyName"
+            "Type" : "AWS::EC2::KeyPair::KeyName"
         },
-        "InstanceType" : {
+        "InstanceType" :
+        {
             "Description" : "Amazon EC2 instance type",
-            "Type"        : "String",
-            "Default"     : "t2.micro",
-            "AllowedValues" : [
+            "Type" : "String",
+            "Default" : "t2.micro",
+            "AllowedValues" :
+            [
                 "t2.micro",
                 "t2.small",
                 "t2.medium",
@@ -25,87 +30,68 @@
                 "m4.xlarge"
             ]
         },
-        "SecurityGroupIds" : {
+        "SecurityGroupIds" :
+        {
             "Description" : "List of security groups to apply to the instance",
-            "Type"        : "List<AWS::EC2::SecurityGroup::Id>"
+            "Type" : "List<AWS::EC2::SecurityGroup::Id>"
         },
-            "SubnetId" : {
-              "Type" : "AWS::EC2::Subnet::Id",
-              "Description" : "ID of the subnet to assign to the instance"
+        "SubnetId" :
+        {
+          "Type" : "AWS::EC2::Subnet::Id",
+          "Description" : "ID of the subnet to assign to the instance"
         }
     },
-    "Mappings" : {
-        "AWSInstanceType2Arch" : {
-            "t2.micro" : {
-                "Arch" : "64"
-            },
-            "t2.small" : {
-                "Arch" : "64"
-            },
-            "t2.medium" : {
-                "Arch" : "64"
-            },
-            "c4.large" : {
-                "Arch" : "64"
-            },
-            "c4.xlarge" : {
-                "Arch" : "64"
-            },
-            "m4.large" : {
-                "Arch" : "64"
-            },
-            "m4.xlarge" : {
-                "Arch" : "64"
-            }
+    "Mappings" :
+    {
+        "AWSInstanceType2Arch" :
+        {
+            "t2.micro" : { "Arch" : "64" },
+            "t2.small" : { "Arch" : "64" },
+            "t2.medium" : { "Arch" : "64" },
+            "c4.large" : { "Arch" : "64" },
+            "c4.xlarge" : { "Arch" : "64" },
+            "m4.large" : { "Arch" : "64" },
+            "m4.xlarge" : { "Arch" : "64" }
         },
-        "AWSRegionArch2AMI" : {
-            "us-east-1" : {
-                "64" : "ami-cd9339a6"
-            },
-            "us-west-2" : {
-                "64" : "ami-4dbcb67d"
-            },
-            "us-west-1" : {
-                "64" : "ami-bf2dd3fb"
-            },
-            "eu-west-1" : {
-                "64" : "ami-1a92cf6d"
-            },
-            "eu-central-1" : {
-                "64" : "ami-86393e9b"
-            },
-            "ap-southeast-1" : {
-                "64" : "ami-12737d40"
-            },
-            "ap-northeast-1" : {
-                "64" : "ami-b4ce74b4"
-            },
-            "ap-southeast-2" : {
-                "64" : "ami-7ddb9847"
-            },
-            "sa-east-1" : {
-                "64" : "ami-89ff7794"
-            }
+        "AWSRegionArch2AMI" :
+        {
+            "us-east-1" : { "64" : "ami-cd9339a6" },
+            "us-west-2" : { "64" : "ami-4dbcb67d" },
+            "us-west-1" : { "64" : "ami-bf2dd3fb" },
+            "eu-west-1" : { "64" : "ami-1a92cf6d" },
+            "eu-central-1" : { "64" : "ami-86393e9b" },
+            "ap-southeast-1" : { "64" : "ami-12737d40" },
+            "ap-northeast-1" : { "64" : "ami-b4ce74b4" },
+            "ap-southeast-2" : { "64" : "ami-7ddb9847" },
+            "sa-east-1" : { "64" : "ami-89ff7794" }
         }
     },
-    "Resources" : {
-        "SystemPrepInstance" : {
+    "Resources" :
+    {
+        "SystemPrepInstance" :
+        {
             "Type" : "AWS::EC2::Instance",
-            "CreationPolicy" : {
-                "ResourceSignal" : {
+            "CreationPolicy" :
+            {
+                "ResourceSignal" :
+                {
                     "Count" : "1",
                     "Timeout" : "PT20M"
                 }
             },
-            "Properties" : {
-                "ImageId" : {
-                    "Fn::FindInMap" : [
+            "Properties" :
+            {
+                "ImageId" :
+                {
+                    "Fn::FindInMap" :
+                    [
                         "AWSRegionArch2AMI",
                         {
                             "Ref" : "AWS::Region"
                         },
                         {
-                            "Fn::FindInMap" : [
+                            "Fn::FindInMap" :
+                            [
                                 "AWSInstanceType2Arch",
                                 {
                                     "Ref" : "InstanceType"
@@ -115,38 +101,48 @@
                         }
                     ]
                 },
-                "InstanceType" : {
+                "InstanceType" :
+                {
                     "Ref" : "InstanceType"
                 },
-                "Tags" : [
+                "Tags" :
+                [
                     {
                         "Key" : "Name",
-                        "Value" : { "Fn::Join" : [ "", [
+                        "Value" :
+                        { "Fn::Join" : [ "", [
                             "SystemPrep-Windows-",
                             { "Ref" : "AWS::StackName" }
                         ]]}
                     }
                 ],
-                "BlockDeviceMappings" : [
+                "BlockDeviceMappings" :
+                [
                     {
                         "DeviceName" : "/dev/sda1",
-                        "Ebs"        : {
+                        "Ebs" :
+                        {
                             "VolumeType" : "gp2",
                             "DeleteOnTermination" : "true"
                         }
                     }
                 ],
-                "KeyName" : {
+                "KeyName" :
+                {
                     "Ref" : "KeyPairName"
                 },
-                "SecurityGroupIds" : {
+                "SecurityGroupIds" :
+                {
                     "Ref" : "SecurityGroupIds"
                 },
-                "SubnetId" : {
+                "SubnetId" :
+                {
                     "Ref" : "SubnetId"
                 },
-                "UserData" : {
-                    "Fn::Base64" : { "Fn::Join" : [ "", [
+                "UserData" :
+                {
+                    "Fn::Base64" :
+                    { "Fn::Join" : [ "", [
                         "<powershell>", "\n",
 
                         "Invoke-WebRequest -URI \"",
@@ -177,11 +173,11 @@
             }
         }
     },
-    "Outputs" : {
-        "SystemPrepInstanceId" : {
-            "Value" : {
-                "Ref" : "SystemPrepInstance"
-            },
+    "Outputs" :
+    {
+        "SystemPrepInstanceId" :
+        {
+            "Value" : { "Ref" : "SystemPrepInstance" },
             "Description" : "Instance ID"
         }
     }

--- a/Utils/cfn/systemprep-win-instance.template
+++ b/Utils/cfn/systemprep-win-instance.template
@@ -1,8 +1,13 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description" : "This template deploys a Windows 2012 R2 instance with the SystemPrep bootstrapper to apply the DISA STIG.",
+    "Description" : "This template deploys a Windows instance with the SystemPrep bootstrapper to apply the DISA STIG.",
     "Parameters" :
     {
+        "AmiId" :
+        {
+            "Description" : "ID of the AMI to launch",
+            "Type" : "String"
+        },
         "BootstrapURL" :
         {
             "Description" : "URL to the SystemPrep Bootstrapper",
@@ -81,30 +86,8 @@
             },
             "Properties" :
             {
-                "ImageId" :
-                {
-                    "Fn::FindInMap" :
-                    [
-                        "AWSRegionArch2AMI",
-                        {
-                            "Ref" : "AWS::Region"
-                        },
-                        {
-                            "Fn::FindInMap" :
-                            [
-                                "AWSInstanceType2Arch",
-                                {
-                                    "Ref" : "InstanceType"
-                                },
-                                "Arch"
-                            ]
-                        }
-                    ]
-                },
-                "InstanceType" :
-                {
-                    "Ref" : "InstanceType"
-                },
+                "ImageId" : { "Ref" : "AmiId" },
+                "InstanceType" : { "Ref" : "InstanceType" },
                 "Tags" :
                 [
                     {

--- a/Utils/cfn/systemprep-win-instance.template
+++ b/Utils/cfn/systemprep-win-instance.template
@@ -6,13 +6,31 @@
         "AmiId" :
         {
             "Description" : "ID of the AMI to launch",
+            "Type" : "String",
+            "AllowedPattern" : "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$"
+        },
+        "AppScriptParams" :
+        {
+            "Description" : "Parameter string to pass to the application script. This parameter is ignored unless \"AppScriptUrl\" is provided",
             "Type" : "String"
         },
-        "BootstrapURL" :
+        "AppScriptShell" :
         {
-            "Description" : "URL to the SystemPrep Bootstrapper",
+            "Description" : "Shell with which to execute the application script. This parameter is ignored unless \"AppScriptUrl\" is provided",
             "Type" : "String",
-            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1"
+            "Default" : "powershell",
+            "AllowedValues" :
+            [
+                "cmd",
+                "powershell"
+            ]
+        },
+        "AppScriptUrl" :
+        {
+            "Description" : "URL to the application script. Leave blank to launch without an application script",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^http://.*$|^https://.*$"
         },
         "KeyPairName" :
         {
@@ -29,10 +47,33 @@
                 "t2.micro",
                 "t2.small",
                 "t2.medium",
+                "t2.large",
                 "c4.large",
                 "c4.xlarge",
                 "m4.large",
                 "m4.xlarge"
+            ]
+        },
+        "NoPublicIp" :
+        {
+            "Description" : "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
+            "Type" : "String",
+            "Default" : "true",
+            "AllowedValues" :
+            [
+                "false",
+                "true"
+            ]
+        },
+        "NoReboot" :
+        {
+            "Description" : "Controls whether to reboot the instance as the last step of cfn-init execution",
+            "Type" : "String",
+            "Default" : "false",
+            "AllowedValues" :
+            [
+                "false",
+                "true"
             ]
         },
         "SecurityGroupIds" :
@@ -44,31 +85,77 @@
         {
           "Type" : "AWS::EC2::Subnet::Id",
           "Description" : "ID of the subnet to assign to the instance"
+        },
+        "SystemPrepBootstrapUrl" :
+        {
+            "Description" : "URL to the SystemPrep Bootstrapper",
+            "Type" : "String",
+            "Default" : "https://s3.amazonaws.com/systemprep/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1",
+            "AllowedPattern" : "^http://.*\\.ps1$|^https://.*\\.ps1$"
+        },
+        "SystemPrepEnvironment" :
+        {
+            "Description" : "Environment in which the instance is being deployed",
+            "Type" : "String",
+            "Default" : "$false",
+            "AllowedValues" :
+            [
+                "$false",
+                "dev",
+                "test",
+                "prod"
+            ]
+        },
+        "SystemPrepOuPath" :
+        {
+            "Description" : "DN of the OU to place the instance when joining a domain. If blank and \"SystemPrepEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"SystemPrepEnvironment\" is \"$false\"",
+            "Type" : "String",
+            "Default" : "",
+            "AllowedPattern" : "^$|^(OU=.+,)+(DC=.+)+$"
+        },
+        "ToggleCfnInitUpdate" :
+        {
+            "Description" : "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
+            "Type" : "String",
+            "Default" : "A",
+            "AllowedValues" :
+            [
+                "A",
+                "B"
+            ]
+        }
+    },
+    "Conditions" :
+    {
+        "ExecuteAppScript" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AppScriptUrl" }, "" ] } ]
+        },
+        "UseOuPath" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "SystemPrepOuPath" }, "" ] } ]
+        },
+        "Reboot" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoReboot" }, "true" ] } ]
+        },
+        "AssignPublicIp" :
+        {
+            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoPublicIp" }, "true" ] } ]
         }
     },
     "Mappings" :
     {
-        "AWSInstanceType2Arch" :
+        "ShellCommandMap" :
         {
-            "t2.micro" : { "Arch" : "64" },
-            "t2.small" : { "Arch" : "64" },
-            "t2.medium" : { "Arch" : "64" },
-            "c4.large" : { "Arch" : "64" },
-            "c4.xlarge" : { "Arch" : "64" },
-            "m4.large" : { "Arch" : "64" },
-            "m4.xlarge" : { "Arch" : "64" }
-        },
-        "AWSRegionArch2AMI" :
-        {
-            "us-east-1" : { "64" : "ami-cd9339a6" },
-            "us-west-2" : { "64" : "ami-4dbcb67d" },
-            "us-west-1" : { "64" : "ami-bf2dd3fb" },
-            "eu-west-1" : { "64" : "ami-1a92cf6d" },
-            "eu-central-1" : { "64" : "ami-86393e9b" },
-            "ap-southeast-1" : { "64" : "ami-12737d40" },
-            "ap-northeast-1" : { "64" : "ami-b4ce74b4" },
-            "ap-southeast-2" : { "64" : "ami-7ddb9847" },
-            "sa-east-1" : { "64" : "ami-89ff7794" }
+            "powershell" :
+            {
+                "command" : "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass"
+            },
+            "cmd" :
+            {
+                "command" : "cmd.exe"
+            }
         }
     },
     "Resources" :
@@ -81,7 +168,243 @@
                 "ResourceSignal" :
                 {
                     "Count" : "1",
-                    "Timeout" : "PT20M"
+                    "Timeout" : "PT60M"
+                }
+            },
+            "Metadata" : {
+                "ToggleCfnInitUpdate" : { "Ref" : "ToggleCfnInitUpdate" },
+                "AWS::CloudFormation::Init" :
+                {
+                    "configSets" :
+                    {
+                        "launch" :
+                        [
+                            "setup",
+                            "systemprep-launch",
+                            {
+                                "Fn::If" :
+                                [
+                                    "ExecuteAppScript",
+                                    "make-app",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            {
+                                "Fn::If" :
+                                [
+                                    "Reboot",
+                                    "reboot",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            "finalize"
+                        ],
+                        "update" :
+                        [
+                            "setup",
+                            "systemprep-update",
+                            {
+                                "Fn::If" :
+                                [
+                                    "ExecuteAppScript",
+                                    "make-app",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            {
+                                "Fn::If" :
+                                [
+                                    "Reboot",
+                                    "reboot",
+                                    { "Ref" : "AWS::NoValue" }
+                                ]
+                            },
+                            "finalize"
+                        ]
+                    },
+                    "setup" :
+                    {
+                        "files" :
+                        {
+                            "c:\\cfn\\cfn-hup.conf" :
+                            {
+                                "content" :
+                                { "Fn::Join" : ["", [
+                                    "[main]\n",
+                                    "stack=", { "Ref" : "AWS::StackId" }, "\n",
+                                    "region=", { "Ref" : "AWS::Region" }, "\n",
+                                    "interval=1", "\n",
+                                    "verbose=true", "\n"
+                                ]]}
+                            },
+                            "c:\\cfn\\hooks.d\\cfn-auto-reloader.conf" :
+                            {
+                                "content" :
+                                { "Fn::Join" : ["", [
+                                    "[cfn-auto-reloader-hook]\n",
+                                    "triggers=post.update\n",
+                                    "path=Resources.SystemPrepInstance.Metadata\n",
+                                    "action=cfn-init.exe -v -c update",
+                                    " --stack ", { "Ref" : "AWS::StackName" },
+                                    " --resource SystemPrepInstance",
+                                    " --region ", { "Ref" : "AWS::Region" }, "\n"
+                                ]]}
+                            },
+                            "c:\\cfn\\scripts\\systemprep-bootstrapper.ps1" :
+                            {
+                                "source" : { "Ref" : "SystemPrepBootstrapUrl" }
+                            }
+                        },
+                        "services" :
+                        {
+                            "windows" :
+                            {
+                                "cfn-hup" :
+                                {
+                                    "enabled" : "true",
+                                    "ensureRunning" : "true",
+                                    "files" :
+                                    [
+                                        "c:\\cfn\\cfn-hup.conf",
+                                        "c:\\cfn\\hooks.d\\cfn-auto-reloader.conf"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "systemprep-launch" :
+                    {
+                        "commands" :
+                        {
+                            "10-systemprep-launch" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    { "Fn::FindInMap" :
+                                        [
+                                            "ShellCommandMap",
+                                            "powershell",
+                                            "command"
+                                        ]
+                                    },
+                                    " c:\\cfn\\scripts\\systemprep-bootstrapper.ps1",
+                                    " -NoReboot \"$true\"",
+                                    " -EntEnv \"",
+                                    { "Ref" : "SystemPrepEnvironment" },
+                                    "\"",
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseOuPath",
+                                            { "Fn::Join" : [ "", [
+                                                " -OuPath \"",
+                                                { "Ref" : "SystemPrepOuPath" },
+                                                "\""
+                                            ]]},
+                                            ""
+                                        ]
+                                    }
+                                ]]},
+                                "waitAfterCompletion" : "0"
+                            }
+                        }
+                    },
+                    "systemprep-update" :
+                    {
+                        "commands" :
+                        {
+                            "10-systemprep-update" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    { "Fn::FindInMap" :
+                                        [
+                                            "ShellCommandMap",
+                                            "powershell",
+                                            "command"
+                                        ]
+                                    },
+                                    " c:\\cfn\\scripts\\systemprep-bootstrapper.ps1",
+                                    " -SaltStates None",
+                                    " -NoReboot \"$true\"",
+                                    " -EntEnv \"",
+                                    { "Ref" : "SystemPrepEnvironment" },
+                                    "\"",
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseOuPath",
+                                            { "Fn::Join" : [ "", [
+                                                " -OuPath \"",
+                                                { "Ref" : "SystemPrepOuPath" },
+                                                "\""
+                                            ]]},
+                                            ""
+                                        ]
+                                    }
+                                ]]},
+                                "waitAfterCompletion" : "0"
+                            }
+                        }
+                    },
+                    "make-app" :
+                    {
+                        "files" :
+                        {
+                            "c:\\cfn\\scripts\\make-app" :
+                            {
+                                "source" : { "Ref" : "AppScriptUrl" }
+                            }
+                        },
+                        "commands" :
+                        {
+                            "10-make-app" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    { "Fn::FindInMap" :
+                                        [
+                                            "ShellCommandMap",
+                                            { "Ref" : "AppScriptShell" },
+                                            "command"
+                                        ]
+                                    },
+                                    " c:\\cfn\\scripts\\make-app ",
+                                    { "Ref" : "AppScriptParams" }
+                                ]]},
+                                "waitAfterCompletion" : "0"
+                            }
+                        }
+                    },
+                    "reboot" :
+                    {
+                        "commands" :
+                        {
+                            "10-reboot" :
+                            {
+                                "command" : "powershell.exe \"Restart-Computer -Force -Verbose\"",
+                                "waitAfterCompletion" : "forever"
+                            }
+                        }
+                    },
+                    "finalize" :
+                    {
+                        "commands" :
+                        {
+                            "10-signal-success" :
+                            {
+                                "command" :
+                                { "Fn::Join" : [ "", [
+                                    "cfn-signal.exe -e 0",
+                                    " --stack ", { "Ref" : "AWS::StackName" },
+                                    " --resource SystemPrepInstance",
+                                    " --region ", { "Ref" : "AWS::Region"}, "\n"
+                                ]]},
+                                "ignoreErrors" : "true",
+                                "waitAfterCompletion" : "0"
+                            }
+                        }
+                    }
                 }
             },
             "Properties" :
@@ -94,7 +417,6 @@
                         "Key" : "Name",
                         "Value" :
                         { "Fn::Join" : [ "", [
-                            "SystemPrep-Windows-",
                             { "Ref" : "AWS::StackName" }
                         ]]}
                     }
@@ -114,43 +436,47 @@
                 {
                     "Ref" : "KeyPairName"
                 },
-                "SecurityGroupIds" :
-                {
-                    "Ref" : "SecurityGroupIds"
-                },
-                "SubnetId" :
-                {
-                    "Ref" : "SubnetId"
-                },
+                "NetworkInterfaces":
+                [
+                    {
+                        "DeviceIndex" : "0",
+                        "AssociatePublicIpAddress" :
+                        {
+                            "Fn::If" :
+                            [
+                                "AssignPublicIp",
+                                "true",
+                                "false"
+                            ]
+                        },
+                        "GroupSet" : { "Ref": "SecurityGroupIds" },
+                        "SubnetId": { "Ref" : "SubnetId" }
+                    }
+                ],
                 "UserData" :
                 {
                     "Fn::Base64" :
                     { "Fn::Join" : [ "", [
-                        "<powershell>", "\n",
+                        "<script>", "\n",
 
-                        "Invoke-WebRequest -URI \"",
-                        {
-                            "Ref" : "BootstrapURL"
-                        },
-                        "\" -OutFile .\\bootstrap.ps1", "\n",
+                        "cfn-init.exe -v -c launch",
+                        " --stack ", { "Ref" : "AWS::StackName" },
+                        " --resource SystemPrepInstance ",
+                        " --region ", { "Ref" : "AWS::Region" }, "\n",
 
-                        "try { ", "\n",
-                        "  .\\bootstrap.ps1", "\n",
-                        "  cfn-signal.exe -e 0 ",
-                        "   --stack ", { "Ref" : "AWS::StackName" },
-                        "   --resource SystemPrepInstance ",
-                        "   --region ", { "Ref" : "AWS::Region" }, "\n",
-                        "}", "\n",
+                        "if %ERRORLEVEL% equ 0 goto success\n\n",
 
-                        "catch { ", "\n",
-                        "  cfn-signal.exe -e 1 ",
-                        "   --stack ", { "Ref" : "AWS::StackName" },
-                        "   --resource SystemPrepInstance ",
-                        "   --region ", { "Ref" : "AWS::Region" }, "\n",
-                        "  throw", "\n",
-                        "}", "\n",
+                        ":error\n",
+                        "cfn-signal.exe -e 1",
+                        " --stack ", { "Ref" : "AWS::StackName" },
+                        " --resource SystemPrepInstance ",
+                        " --region ", { "Ref" : "AWS::Region" }, "\n",
+                        "echo \"ERROR: cfn-init failed! Aborting!\"", "\n",
+                        "exit /b 1\n\n",
 
-                        "</powershell>"
+                        ":success\n",
+
+                        "</script>"
                     ] ] }
                 }
             }


### PR DESCRIPTION
This PR updates the cfn example templates to support a number of new parameters and functionality:

* Three parameters support the ability to execute a script to install an application: `AppScriptUrl`, `AppScriptShell`, and `AppScriptParams`.
* The templates have all been converted to use resource metadata and the cfn utilities to execute tasks during stack launch and stack update.
  * Use the parameter `ToggleCfnInitUpdate` during a stack update to force a change to metadata, resulting in the execution of the 'update' tasks.
  * Use the parameter `ToggleNewInstances` (Autoscale-only) to deploy new instances during a stack update (by changing the userdata, which triggers the UpdatePolicy on the AutoScale group and initiates a RollingUpdate).
* Control whether the instance(s) reboot after executing the cfn-init tasks using the parameter `NoReboot`.
* Control whether to assign a public IP to the instance(s) using the parameter `NoPublicIp`.
* (Linux only) Control whether to install patches with `yum -y update` during a stack update with the parameter `NoUpdates`.