### PR TITLE
Removing crash issue

### DIFF
--- a/MasterScripts/systemprep-linuxmaster.py
+++ b/MasterScripts/systemprep-linuxmaster.py
@@ -324,10 +324,8 @@ def main(noreboot = 'false', **kwargs):
     print('-' * 80)
 
 if "__main__" == __name__:
-    # Convert command line parameters of the form `param=value` to a dict
-    # If CL param does not contain '=', store param as a key with None value
-    # NOTE: Do we prefer this program to raise error if there is a CL param with no '=' in it?
-    # NOTE: Keys are store in lowercase format.
+    # Convert command line parameters of the form `param=value` to a dictionary.
+    # NOTE: Keys are stored in lowercase format.
     kwargs = {}
     for x in sys.argv[1:]:
         if '=' in x:

--- a/MasterScripts/systemprep-linuxmaster.py
+++ b/MasterScripts/systemprep-linuxmaster.py
@@ -325,9 +325,16 @@ def main(noreboot='false', **kwargs):
 
 
 if "__main__" == __name__:
-    #convert command line parameters of the form `param=value` to a dict
-    kwargs = dict(x.split('=', 1) for x in sys.argv[1:])
-    #Convert parameter keys to lowercase, parameter values are unmodified
-    kwargs = dict((k.lower(), v) for k, v in kwargs.items())
+    # Convert command line parameters of the form `param=value` to a dict
+    # If CL param does not contain '=', store param as a key with None value
+    # NOTE: Do we prefer this program to raise error if there is a CL param with no '=' in it?
+    # NOTE: Keys are store in lowercase format.
+    kwargs = {}
+    for x in sys.argv[1:]:
+        if '=' in x:
+            [key, value] = x.split('=', 1)
+            kwargs[key.lower()] = value
+        else:
+            kwargs[x] = None
 
     main(**kwargs)

--- a/MasterScripts/systemprep-linuxmaster.py
+++ b/MasterScripts/systemprep-linuxmaster.py
@@ -260,9 +260,9 @@ def cleanup(workingdir):
     return True
 
 
-def main(noreboot='false', **kwargs):
+def main(noreboot = 'false', **kwargs):
     """
-    Master Script that calls content scripts to be deployed when provisioning systems
+    Master script that calls content scripts to be deployed when provisioning systems
     """
 
     # NOTE: Using __file__ may freeze if trying to build an executable, e.g. via py2exe.
@@ -274,7 +274,7 @@ def main(noreboot='false', **kwargs):
     else:
         scriptname = os.path.abspath(sys.argv[0])
 
-    #Check special parameter types
+    # Check special parameter types
     noreboot = 'true' == noreboot.lower()
     sourceiss3bucket = 'true' == kwargs.get('sourceiss3bucket', 'false').lower()
 
@@ -323,7 +323,6 @@ def main(noreboot='false', **kwargs):
     print('{0} complete!'.format(scriptname))
     print('-' * 80)
 
-
 if "__main__" == __name__:
     # Convert command line parameters of the form `param=value` to a dict
     # If CL param does not contain '=', store param as a key with None value
@@ -335,6 +334,11 @@ if "__main__" == __name__:
             [key, value] = x.split('=', 1)
             kwargs[key.lower()] = value
         else:
-            kwargs[x] = None
+            message = 'Encountered a parameter that does not have = in it.'
+            raise SystemError(message)
 
+    # NOTE: We are unpacking kwargs to obtain the noreboot parameter for the main
+    # definition.  The rest are packed back into kwargs.
+    # TODO: This is not necessary and consumes a minor overhead. I would just pass along the dictionary.
+    # However, since we will be moving to using argparse, this will become obsolete.
     main(**kwargs)


### PR DESCRIPTION
Updated code to remove possibility of Python script crashing if a command line parameter does not have '=' in it.  Also, reduces the number of loops down to 1 instead of 2 - yes, number of lines of code is not as concise but alas.

BUT, before committing to merging, need to decide if we wish to go on with script if a parameter does not have '=' in it and assume all appropriate parameters are still inputted, OR do we wish to raise an error if the such a possibility arises.