### PR TITLE
Adds support to configure AdminGroups and AdminUsers

### DIFF
--- a/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1
+++ b/BootStrapScripts/SystemPrep-Bootstrap--Windows.ps1
@@ -17,6 +17,10 @@ Param(
     ,
     $ComputerName = $false
     ,
+    $AdminGroups = $false
+    ,
+    $AdminUsers = $false
+    ,
     [Bool]$SourceIsS3Bucket = $false
     ,
     [String]$AwsRegion = 'us-east-1'
@@ -40,6 +44,8 @@ $SystemPrepParams = @{
     EntEnv = ${EntEnv}
     OuPath = ${OuPath}
     ComputerName = ${ComputerName}
+    AdminGroups = ${AdminGroups}
+    AdminUsers = ${AdminUsers}
     SaltStates = "${SaltStates}"
     SaltContentUrl = "${SaltContentUrl}"
     NoReboot = ${NoReboot}

--- a/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-DomainController.txt
+++ b/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-DomainController.txt
@@ -3,12 +3,16 @@
 $EntEnv = $false
 $OuPath = $false
 $ComputerName = $false
+$AdminGroups = $false
+$AdminUsers = $false
 $SystemPrepMasterScriptUrl = 'https://s3.amazonaws.com/systemprep/MasterScripts/SystemPrep-WindowsMaster.ps1'
 $SystemPrepParams = @{
     AshRole = "DomainController"
     EntEnv = $EntEnv
     OuPath = $OuPath
     ComputerName = $ComputerName
+    AdminGroups = $AdminGroups
+    AdminUsers = $AdminUsers
     SaltStates = "Highstate"
     SaltContentUrl = "https://s3.amazonaws.com/systemprep-content/windows/salt/salt-content.zip"
     NoReboot = $false

--- a/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-MemberServer.txt
+++ b/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows-MemberServer.txt
@@ -3,12 +3,16 @@
 $EntEnv = $false
 $OuPath = $false
 $ComputerName = $false
+$AdminGroups = $false
+$AdminUsers = $false
 $SystemPrepMasterScriptUrl = 'https://s3.amazonaws.com/systemprep/MasterScripts/SystemPrep-WindowsMaster.ps1'
 $SystemPrepParams = @{
     AshRole = "MemberServer"
     EntEnv = $EntEnv
     OuPath = $OuPath
     ComputerName = $ComputerName
+    AdminGroups = $AdminGroups
+    AdminUsers = $AdminUsers
     SaltStates = "Highstate"
     SaltContentUrl = "https://s3.amazonaws.com/systemprep-content/windows/salt/salt-content.zip"
     NoReboot = $false

--- a/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows.txt
+++ b/BootStrapScripts/SystemPrep-Bootstrap-EC2-Windows.txt
@@ -3,12 +3,16 @@
 $EntEnv = $false
 $OuPath = $false
 $ComputerName = $false
+$AdminGroups = $false
+$AdminUsers = $false
 $SystemPrepMasterScriptUrl = 'https://s3.amazonaws.com/systemprep/MasterScripts/SystemPrep-WindowsMaster.ps1'
 $SystemPrepParams = @{
     AshRole = "MemberServer"
     EntEnv = $EntEnv
     OuPath = $OuPath
     ComputerName = $ComputerName
+    AdminGroups = $AdminGroups
+    AdminUsers = $AdminUsers
     SaltStates = "Highstate"
     SaltContentUrl = "https://s3.amazonaws.com/systemprep-content/windows/salt/salt-content.zip"
     NoReboot = $false


### PR DESCRIPTION
This commit exposes bootstrap parameters for AdminGroups and AdminUsers.
The parameters are used to set the `join-domain:admin_groups` and
`join-domain:admin_users` grains, which are read by the join-domain
formula. The formula will configure the system to grant the specified
domain users/groups local root/admin privileges.

These parameters are colon-separated strings. E.g. 'value1:value2'.

Fixes #95